### PR TITLE
Pass 'multi-initiator' flag via create options to CSP

### DIFF
--- a/pkg/driver/constants.go
+++ b/pkg/driver/constants.go
@@ -44,6 +44,7 @@ const (
 	chapPasswordKey     = "chapPassword"
 	readOnlyKey         = "readOnly"
 	volumeAccessModeKey = "volumeAccessMode"
+	multiInitiatorKey   = "multiInitiator"
 
 	// deviceInfoFileName is used to store the device details in a JSON file
 	deviceInfoFileName = "deviceInfo.json"

--- a/pkg/driver/controller_server.go
+++ b/pkg/driver/controller_server.go
@@ -335,6 +335,11 @@ func (driver *Driver) createVolume(
 		// convert create options to snakecase before passing it to CSP
 		createOptions[util.ToSnakeCase(k)] = v
 	}
+
+	// Get the multi-initiator access mode
+	multiInitiator := driver.IsSupportedMultiNodeAccessMode(volumeCapabilities)
+	createOptions[util.ToSnakeCase(multiInitiatorKey)] = multiInitiator
+
 	log.Trace("Volume create options: ", createOptions)
 
 	// extract the description if present

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -221,6 +221,8 @@ func (driver *Driver) IsSupportedMultiNodeAccessMode(capabilities []*csi.VolumeC
 		switch volCap.GetAccessMode().GetMode() {
 		case csi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY:
 			fallthrough
+		case csi.VolumeCapability_AccessMode_MULTI_NODE_SINGLE_WRITER:
+			fallthrough
 		case csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER:
 			return true
 		}


### PR DESCRIPTION
- Updated util function 'IsSupportedMultiNodeAccessMode' to check for multi-initiator status
- Added new option flag 'multi_initiator' to pass via create options.