### PR TITLE
csi: cleanup stale device before stage and always attempt create of s…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway v1.12.0 // indirect
 	github.com/hashicorp/golang-lru v0.5.3 // indirect
-	github.com/hpe-storage/common-host-libs v0.0.0-20191116160841-21b92fca77d7
+	github.com/hpe-storage/common-host-libs v0.0.0-20191125214838-865199deaa22
 	github.com/hpe-storage/k8s-custom-resources v0.0.0-20190828052325-42886f48215c
 	github.com/jonboulle/clockwork v0.1.0 // indirect
 	github.com/json-iterator/go v1.1.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -138,6 +138,8 @@ github.com/hpe-storage/common-host-libs v0.0.0-20191023151626-8099ba365825 h1:IR
 github.com/hpe-storage/common-host-libs v0.0.0-20191023151626-8099ba365825/go.mod h1:qQxvwt4l9C79p2V8bY1P13As1+ylyznKJVp3K2P5bz8=
 github.com/hpe-storage/common-host-libs v0.0.0-20191116160841-21b92fca77d7 h1:EcxuhZ8N/P+Gii2bGPbZcFufp5ys4U55P6t7Tz+WwEQ=
 github.com/hpe-storage/common-host-libs v0.0.0-20191116160841-21b92fca77d7/go.mod h1:qQxvwt4l9C79p2V8bY1P13As1+ylyznKJVp3K2P5bz8=
+github.com/hpe-storage/common-host-libs v0.0.0-20191125214838-865199deaa22 h1:8VR3iGYlzIs0dcUQUtA1Z457Uls3/AaUIwhR9AW+pvw=
+github.com/hpe-storage/common-host-libs v0.0.0-20191125214838-865199deaa22/go.mod h1:qQxvwt4l9C79p2V8bY1P13As1+ylyznKJVp3K2P5bz8=
 github.com/hpe-storage/k8s-custom-resources v0.0.0-20190828052325-42886f48215c h1:M/4pHhSouEEjd613SFODOskZmn6pS5tWITHdA8MPWMI=
 github.com/hpe-storage/k8s-custom-resources v0.0.0-20190828052325-42886f48215c/go.mod h1:qYST/Hepa2MRB85zskShx/+WlbUG5bmq/orhy6sA2jE=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=

--- a/pkg/driver/node_server.go
+++ b/pkg/driver/node_server.go
@@ -445,6 +445,16 @@ func (driver *Driver) setupDevice(publishContext map[string]string) (*model.Devi
 		volume.Chap = chapInfo
 	}
 
+	// Cleanup any stale device existing before stage
+	device, err := driver.chapiDriver.GetDevice(volume)
+	if device != nil {
+		device.TargetScope = volume.TargetScope
+		err = driver.chapiDriver.DeleteDevice(device)
+		if err != nil {
+			log.Warnf("Failed to cleanup stale device %s before staging, err %s", device.AltFullPathName, err.Error())
+		}
+	}
+
 	// Create Device
 	devices, err := driver.chapiDriver.CreateDevices([]*model.Volume{volume})
 	if err != nil {
@@ -1630,6 +1640,14 @@ func writeStagedDeviceInfo(targetPath string, stagingDev *StagingDevice) error {
 	if err != nil {
 		return err
 	}
+
+	// Attempt create of staging dir, as CSI attacher can remove the directory
+	// while operation is still pending(during retries)
+	if err = os.MkdirAll(targetPath, 0750); err != nil {
+		log.Errorf("Failed to create staging dir %s err: %v", targetPath, err)
+		return err
+	}
+
 	// Write to file
 	filename := path.Join(targetPath, deviceInfoFileName)
 	err = ioutil.WriteFile(filename, deviceInfo, 0600)

--- a/vendor/github.com/hpe-storage/common-host-libs/chapi/chapidriver.go
+++ b/vendor/github.com/hpe-storage/common-host-libs/chapi/chapidriver.go
@@ -14,6 +14,7 @@ type Driver interface {
 	GetHostNetworks() ([]*model.Network, error)
 	GetHostNameAndDomain() ([]string, error)
 	CreateDevices(volumes []*model.Volume) ([]*model.Device, error)
+	GetDevice(volume *model.Volume) (*model.Device, error)
 	DeleteDevice(device *model.Device) error
 	OfflineDevice(device *model.Device) error
 	MountDevice(device *model.Device, mountPoint string, mountOptions []string, fsOpts *model.FilesystemOpts) (*model.Mount, error) // Idempotent

--- a/vendor/github.com/hpe-storage/common-host-libs/chapi/chapidriver_darwin.go
+++ b/vendor/github.com/hpe-storage/common-host-libs/chapi/chapidriver_darwin.go
@@ -92,6 +92,11 @@ func (driver *MacDriver) BindMountDevice(mountPoint string, newMountPoint string
 	return fmt.Errorf("not implemented")
 }
 
+// GetDevice will return device matching given volume serial
+func (driver *MacDriver) GetDevice(volume *model.Volume) (*model.Device, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
 // CreateDevices will create devices on this host based on the volume details provided
 func (driver *MacDriver) CreateDevices(volumes []*model.Volume) ([]*model.Device, error) {
 	return nil, fmt.Errorf("not implemented")

--- a/vendor/github.com/hpe-storage/common-host-libs/chapi/chapidriver_fake.go
+++ b/vendor/github.com/hpe-storage/common-host-libs/chapi/chapidriver_fake.go
@@ -47,6 +47,15 @@ func (driver *FakeDriver) GetHostNameAndDomain() ([]string, error) {
 	}, nil
 }
 
+// GetDevice will return device matching given volume serial
+func (driver *FakeDriver) GetDevice(volume *model.Volume) (*model.Device, error) {
+	device := &model.Device{
+		SerialNumber:    volume.SerialNumber,
+		AltFullPathName: "/dev/mapper/fakeMpath",
+	}
+	return device, nil
+}
+
 // CreateDevices will create devices on this host based on the volume details provided
 func (driver *FakeDriver) CreateDevices(volumes []*model.Volume) ([]*model.Device, error) {
 	device := &model.Device{

--- a/vendor/github.com/hpe-storage/common-host-libs/chapi/chapidriver_linux.go
+++ b/vendor/github.com/hpe-storage/common-host-libs/chapi/chapidriver_linux.go
@@ -166,6 +166,10 @@ func (driver *LinuxDriver) CreateDevices(volumes []*model.Volume) ([]*model.Devi
 	return linux.CreateNimbleDevices(volumes)
 }
 
+func (driver *LinuxDriver) GetDevice(volume *model.Volume) (*model.Device, error) {
+	return linux.GetDeviceFromVolume(volume)
+}
+
 // CreateFilesystemOnDevice writes the given filesystem on the given device
 func (driver *LinuxDriver) CreateFilesystemOnDevice(device *model.Device, filesystemType string) error {
 	log.Tracef(">>>>> CreateFilesystemOnDevice, device: %+v, type: %s", device, filesystemType)

--- a/vendor/github.com/hpe-storage/common-host-libs/linux/multipath.go
+++ b/vendor/github.com/hpe-storage/common-host-libs/linux/multipath.go
@@ -181,15 +181,9 @@ func retryCleanupDeviceAndSlaves(dev *model.Device) error {
 	log.Trace(">>>>> retryCleanupDeviceAndSlaves")
 	defer log.Trace("<<<<< retryCleanupDeviceAndSlaves")
 
-	//check if device is mounted or has holders
-	err := checkIfDeviceCanBeDeleted(dev)
-	if err != nil {
-		return err
-	}
-
 	// check if mpathName exists for the device, else populate it
 	if dev.MpathName == "" {
-		err = setAltFullPathName(dev)
+		err := setAltFullPathName(dev)
 		if err != nil {
 			return err
 		}
@@ -329,6 +323,7 @@ func multipathRemoveDmDevice(dev *model.Device) (err error) {
 	if err != nil {
 		return fmt.Errorf("failed to remove multipath device %s. Error: %s ", dev.MpathName, err.Error())
 	}
+
 	log.Debugf("successfully removed the dm device %s", dev.MpathName)
 	return nil
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -68,7 +68,7 @@ github.com/hpcloud/tail/ratelimiter
 github.com/hpcloud/tail/util
 github.com/hpcloud/tail/watch
 github.com/hpcloud/tail/winfile
-# github.com/hpe-storage/common-host-libs v0.0.0-20191116160841-21b92fca77d7
+# github.com/hpe-storage/common-host-libs v0.0.0-20191125214838-865199deaa22
 github.com/hpe-storage/common-host-libs/dbservice/etcd
 github.com/hpe-storage/common-host-libs/logger
 github.com/hpe-storage/common-host-libs/tunelinux


### PR DESCRIPTION
…taging directory

* Problem:
  * During staging, there can be stale devices lying around on the host(with different LUN ID prior)
  * These devices, can cause mismatch issues and wrong LUN ID getting added to maps
  * Also, during staging, external provisioner is cleaning up directory if timeout happens or when retries were aborted.
  * Due to this, current operation fails with error "no such file or directory" and causing full stage sequence again.
* Implementation:
  * Always cleanup on host before performing staging, if stale device is found. As duplicate stage requests are not possible
  * with lock, we can safely assume already attached device is stale.
  * Always attempt to create staging directory before writing deviceInfo. Thus even if external provisioner cleans up staging
  * path(due to timeout or abort errors), we write the deviceInfo and during next retry, we can return without actual device attach again.
* Testing: performed failover/failback with GST devices(50)
* Review: gcostea, rkumar
Signed-off-by: Shiva Krishna, Merla <shivakrishna.merla@hpe.com>