### PR TITLE
csi-driver: comment out udev rule automatically scanning targets/luns

### DIFF
--- a/cmd/csi-driver/conform/hpe-storage-node.sh
+++ b/cmd/csi-driver/conform/hpe-storage-node.sh
@@ -55,5 +55,12 @@ else
     exit 1
 fi
 
-# load iscsi_tcp modules, its a no-op if its already loaded
+# Load iscsi_tcp modules, its a no-op if its already loaded
 modprobe iscsi_tcp
+
+# Don't let udev automatically scan targets(all luns) on Unit Attention.
+# This will prevent udev scanning devices which we are attempting to remove
+if [ -f /lib/udev/rules.d/90-scsi-ua.rules ]; then
+    sed -i 's/^[^#]*scan-scsi-target/#&/' /lib/udev/rules.d/90-scsi-ua.rules
+    udevadm control --reload-rules
+fi


### PR DESCRIPTION
* Problem:
  * Some OS distributions has libstoragemgmt pkg installed by default and this package
  * places 90-scsi-ua.rules which rescans all LUN's on target on which UA is reported.
  * Thus on FC or Group scoped target systems, soon after NodeUnstage, devices are discovered
  * back again. Later when ControllerUnpublish is complete, they end up as dead paths, causing
  * multipathd to poll the forever and log spew. They will also cause conflicts with future LUN's
  * that will be mapped to this host.
* Implementation:
  * libstoragemgmt has very little usage in container environments as storage provisioning is mostly
  * with CSI/Flexvolume drivers. So, comment out this rule during our CSI driver install.
* Testing: deploy and verify the rule gets commented out.
* Review: gcostea, rkumar, sbyadarahalli
* Bug: https://nimblejira.nimblestorage.com/browse/CON-537
Signed-off-by: Shiva Krishna, Merla <shivakrishna.merla@hpe.com>