### PR TITLE
revert tag to not use branch name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,12 +6,7 @@ endif
 # Use the latest git tag
 TAG = $(shell git tag|tail -n1)
 ifeq ($(TAG),)
-	BRANCH = $(shell git rev-parse --abbrev-ref HEAD)
-	ifeq ($(BRANCH), master)
-		TAG = edge
-	else
-		TAG = ${BRANCH}
-	endif
+	TAG = v1.0.0
 endif
 
 # unless a BUILD_NUMBER is specified


### PR DESCRIPTION
* Problem:
- additional search filter needed in artifactory for each branch
was getting cumbersome
