### PR TITLE
update master to use edge tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,7 @@ ifndef REPO_NAME
 	REPO_NAME ?= hpestorage/csi-driver
 endif
 
-# Use the latest git tag
-TAG = $(shell git tag|tail -n1)
-ifeq ($(TAG),)
-	TAG = edge
-endif
+TAG = edge
 
 # unless a BUILD_NUMBER is specified
 ifeq ($(IGNORE_BUILD_NUMBER),true)


### PR DESCRIPTION
* Problem:
- git tag returns the latest released tag whic is v1.0.0
which is what master will use.
* Implementation:
- hard code the TAG when we branch and use edge for the master