### PR TITLE
csi: move to ubi and use chroot mechnism for host utilities

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,6 @@ else
 	endif
 endif
 
-
 # refers to dockerhub if registry is not specified
 IMAGE = $(REPO_NAME):$(VERSION)
 ifdef CONTAINER_REGISTRY
@@ -91,6 +90,8 @@ image:
 	cp ../cmd/csi-driver/rescan-scsi-bus.sh . && \
 	cp -r ../cmd/csi-driver/conform/ conform/ && \
 	cp -r ../cmd/csi-driver/diag/ diag/ && \
+	cp -r ../cmd/csi-driver/chroot-host-wrapper.sh . && \
+	cp -r ../LICENSE . && \
 	rsync -r --no-perms --no-owner --no-group  $(TUNE_LINUX_CONFIG_PATH)/ tune/ && \
 	docker build -t $(IMAGE) .
 

--- a/cmd/csi-driver/Dockerfile
+++ b/cmd/csi-driver/Dockerfile
@@ -34,8 +34,7 @@ RUN ln -s /chroot/chroot-host-wrapper.sh /chroot/blkid \
     && ln -s /chroot/chroot-host-wrapper.sh /chroot/multipathd \
     && ln -s /chroot/chroot-host-wrapper.sh /chroot/umount \
     && ln -s /chroot/chroot-host-wrapper.sh /chroot/ip \
-    && ln -s /chroot/chroot-host-wrapper.sh /chroot/dmidecode \
-    && ln -s /chroot/chroot-host-wrapper.sh /chroot/dmsetup
+    && ln -s /chroot/chroot-host-wrapper.sh /chroot/dmidecode
 
 ENV PATH="/chroot:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 

--- a/cmd/csi-driver/Dockerfile
+++ b/cmd/csi-driver/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi7/ubi-minimal:7.7-138
+FROM registry.access.redhat.com/ubi7/ubi-minimal:7.7-238
 
 LABEL name="HPE CSI Driver for Kubernetes" \
       maintainer="HPE Storage" \
@@ -16,7 +16,7 @@ COPY /LICENSE /licenses/
 RUN mkdir /chroot
 ADD chroot-host-wrapper.sh /chroot
 RUN chmod 777 /chroot/chroot-host-wrapper.sh
-RUN    ln -s /chroot/chroot-host-wrapper.sh /chroot/blkid \
+RUN ln -s /chroot/chroot-host-wrapper.sh /chroot/blkid \
     && ln -s /chroot/chroot-host-wrapper.sh /chroot/blockdev \
     && ln -s /chroot/chroot-host-wrapper.sh /chroot/iscsiadm \
     && ln -s /chroot/chroot-host-wrapper.sh /chroot/lsblk \
@@ -36,8 +36,7 @@ RUN    ln -s /chroot/chroot-host-wrapper.sh /chroot/blkid \
     && ln -s /chroot/chroot-host-wrapper.sh /chroot/ip \
     && ln -s /chroot/chroot-host-wrapper.sh /chroot/dmidecode \
     && ln -s /chroot/chroot-host-wrapper.sh /chroot/systemctl \
-     && ln -s /chroot/chroot-host-wrapper.sh /chroot/dmsetup
-
+    && ln -s /chroot/chroot-host-wrapper.sh /chroot/dmsetup
 
 ENV PATH="/chroot:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 

--- a/cmd/csi-driver/Dockerfile
+++ b/cmd/csi-driver/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi7/ubi-minimal:7.7-238
+FROM registry.access.redhat.com/ubi7/ubi-init:7.7-18.1575996389
 
 LABEL name="HPE CSI Driver for Kubernetes" \
       maintainer="HPE Storage" \
@@ -35,7 +35,6 @@ RUN ln -s /chroot/chroot-host-wrapper.sh /chroot/blkid \
     && ln -s /chroot/chroot-host-wrapper.sh /chroot/umount \
     && ln -s /chroot/chroot-host-wrapper.sh /chroot/ip \
     && ln -s /chroot/chroot-host-wrapper.sh /chroot/dmidecode \
-    && ln -s /chroot/chroot-host-wrapper.sh /chroot/systemctl \
     && ln -s /chroot/chroot-host-wrapper.sh /chroot/dmsetup
 
 ENV PATH="/chroot:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"

--- a/cmd/csi-driver/Dockerfile
+++ b/cmd/csi-driver/Dockerfile
@@ -1,17 +1,45 @@
-FROM debian:stretch
-RUN apt-get update && \
-    apt-get install -y \
-    multipath-tools \
-    e2fsprogs \
-    btrfs-progs \
-    xfsprogs \
-    iproute2 \
-    util-linux \
-    systemd \
-    libisns0 \
-    gawk \
-    nfs-common \
-    dmidecode
+FROM registry.access.redhat.com/ubi7/ubi-minimal:7.7-138
+
+LABEL name="HPE CSI Driver for Kubernetes" \
+      maintainer="HPE Storage" \
+      vendor="HPE" \
+      version="1.1.0" \
+      summary="HPE CSI Driver for Kubernetes" \
+      description="The HPE CSI Driver for Kubernetes enables container orchestrators, such as Kubernetes and OpenShift, to manage the life-cycle of persistent storage." \
+      io.k8s.display-name="HPE CSI Driver for Kubernetes" \
+      io.k8s.description="The HPE CSI Driver for Kubernetes enables container orchestrators, such as Kubernetes and OpenShift, to manage the life-cycle of persistent storage." \
+      io.openshift.tags=hpe,csi,hpe-csi-driver
+
+WORKDIR /root
+COPY /LICENSE /licenses/
+
+RUN mkdir /chroot
+ADD chroot-host-wrapper.sh /chroot
+RUN chmod 777 /chroot/chroot-host-wrapper.sh
+RUN    ln -s /chroot/chroot-host-wrapper.sh /chroot/blkid \
+    && ln -s /chroot/chroot-host-wrapper.sh /chroot/blockdev \
+    && ln -s /chroot/chroot-host-wrapper.sh /chroot/iscsiadm \
+    && ln -s /chroot/chroot-host-wrapper.sh /chroot/lsblk \
+    && ln -s /chroot/chroot-host-wrapper.sh /chroot/lsscsi \
+    && ln -s /chroot/chroot-host-wrapper.sh /chroot/mkfs.ext3 \
+    && ln -s /chroot/chroot-host-wrapper.sh /chroot/mkfs.ext4 \
+    && ln -s /chroot/chroot-host-wrapper.sh /chroot/mkfs.xfs \
+    && ln -s /chroot/chroot-host-wrapper.sh /chroot/mkfs.btrfs \
+    && ln -s /chroot/chroot-host-wrapper.sh /chroot/xfs_growfs \
+    && ln -s /chroot/chroot-host-wrapper.sh /chroot/resize2fs \
+    && ln -s /chroot/chroot-host-wrapper.sh /chroot/btrfs \
+    && ln -s /chroot/chroot-host-wrapper.sh /chroot/fsck \
+    && ln -s /chroot/chroot-host-wrapper.sh /chroot/mount \
+    && ln -s /chroot/chroot-host-wrapper.sh /chroot/multipath \
+    && ln -s /chroot/chroot-host-wrapper.sh /chroot/multipathd \
+    && ln -s /chroot/chroot-host-wrapper.sh /chroot/umount \
+    && ln -s /chroot/chroot-host-wrapper.sh /chroot/ip \
+    && ln -s /chroot/chroot-host-wrapper.sh /chroot/dmidecode \
+    && ln -s /chroot/chroot-host-wrapper.sh /chroot/systemctl \
+     && ln -s /chroot/chroot-host-wrapper.sh /chroot/dmsetup
+
+
+ENV PATH="/chroot:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
 # add host conformance checks and configuration
 ADD [ "conform/*", "/opt/hpe-storage/lib/" ]

--- a/cmd/csi-driver/chroot-host-wrapper.sh
+++ b/cmd/csi-driver/chroot-host-wrapper.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+ME=`basename "$0"`
+DIR="/host"
+if [ ! -d "${DIR}" ]; then
+    echo "Could not find docker engine host's filesystem at expected location: ${DIR}"
+    exit 1
+fi
+
+exec chroot /host /usr/bin/env -i PATH="/sbin:/bin:/usr/bin" ${ME} "${@:1}"

--- a/cmd/csi-driver/chroot-host-wrapper.sh
+++ b/cmd/csi-driver/chroot-host-wrapper.sh
@@ -7,4 +7,4 @@ if [ ! -d "${DIR}" ]; then
     exit 1
 fi
 
-exec chroot /host /usr/bin/env -i PATH="/sbin:/bin:/usr/bin" ${ME} "${@:1}"
+exec chroot /host /usr/bin/env -i PATH="/sbin:/bin:/usr/bin:/usr/sbin" ${ME} "${@:1}"

--- a/cmd/csi-driver/conform/entrypoint.sh
+++ b/cmd/csi-driver/conform/entrypoint.sh
@@ -17,10 +17,10 @@ if [ "$nodeservice" = true ]; then
     else
         # Copy HPE Storage Node Conformance checks and conf in place
         cp -f "/opt/hpe-storage/lib/hpe-storage-node.service" \
-          /lib/systemd/system/hpe-storage-node.service
+          /etc/systemd/system/hpe-storage-node.service
         cp -f "/opt/hpe-storage/lib/hpe-storage-node.sh" \
-          /usr_local/local/bin/hpe-storage-node.sh
-        chmod +x /usr_local/local/bin/hpe-storage-node.sh
+          /etc/hpe-storage/hpe-storage-node.sh
+        chmod +x /etc/hpe-storage/hpe-storage-node.sh
 
         echo "running node conformance checks..."
         # Reload and run!
@@ -33,6 +33,13 @@ if [ "$nodeservice" = true ]; then
     cp -f "/opt/hpe-storage/bin/hpe-logcollector.sh" \
         /usr/local/bin/hpe-logcollector.sh
     chmod +x  /usr/local/bin/hpe-logcollector.sh
+
+    # Copy /etc/multipath.conf template if missing on host
+    if [ ! -f /host/etc/multipath.conf ]; then
+        cp /opt/hpe-storage/nimbletune/multipath.conf.upstream /host/etc/multipath.conf
+    fi
+    # symlink to host file
+    ln -s /host/etc/multipath.conf /etc/multipath.conf
 fi
 
 echo "starting csi plugin..."

--- a/cmd/csi-driver/conform/entrypoint.sh
+++ b/cmd/csi-driver/conform/entrypoint.sh
@@ -38,8 +38,21 @@ if [ "$nodeservice" = true ]; then
     if [ ! -f /host/etc/multipath.conf ]; then
         cp /opt/hpe-storage/nimbletune/multipath.conf.upstream /host/etc/multipath.conf
     fi
-    # symlink to host file
+    # symlink to host iscsi/multipath config files
     ln -s /host/etc/multipath.conf /etc/multipath.conf
+    ln -s /host/etc/multipath /etc/multipath
+    ln -s /host/etc/iscsi /etc/iscsi
+    # symlink to host os release files for parsing
+    if [ -f /host/etc/redhat-release ]; then
+        # remove existing file from ubi
+        rm /etc/redhat-release
+        ln -s /host/etc/redhat-release /etc/redhat-release
+    fi
+    if [ -f /host/etc/os-release ]; then
+        # remove existing file from ubi
+        rm /etc/os-release
+        ln -s /host/etc/os-release /etc/os-release
+    fi
 fi
 
 echo "starting csi plugin..."

--- a/cmd/csi-driver/conform/hpe-storage-node.service
+++ b/cmd/csi-driver/conform/hpe-storage-node.service
@@ -9,7 +9,7 @@ After=network.target network-online.target
 # fork the process so systemd waits until package installation is complete, before starting plugin
 Type=forking
 RemainAfterExit=true
-ExecStart=/usr/local/bin/hpe-storage-node.sh
+ExecStart=/etc/hpe-storage/hpe-storage-node.sh
 StandardOutput=journal
 
 [Install]

--- a/pkg/driver/node_server.go
+++ b/pkg/driver/node_server.go
@@ -583,7 +583,7 @@ func (driver *Driver) nodeUnstageVolume(volumeID string, stagingTargetPath strin
 	// If mounted, then unmount the filesystem
 	if stagingDev.VolumeAccessMode == model.MountType && stagingDev.MountInfo != nil {
 		// Remove the stale bindMounts if any
-		if err := driver.removeStaleBindMounts(stagingDev.Device, stagingTargetPath); err != nil {
+		if err := driver.removeStaleBindMounts(stagingDev.Device, stagingDev.MountInfo.MountPoint); err != nil {
 			return status.Error(codes.Internal,
 				fmt.Sprintf("Error while deleting the stale bind mounts for the staged device %v, err: %s", stagingDev, err.Error()))
 		}


### PR DESCRIPTION
    Problem:
        Need uniform image to support across OCP and other K8s flavors
        Need to minimize dependency of packages within container from
        underlying host libs(eg, iscsi, systemd deps between RHEL7 vs
        RHEL 8 etc)
    Implementation:
        Switched CSI driver image from debian based to UBI 7 minimal
        Removed un-necessary mount paths with deployment and use chroot instead
        with host root fs mounted within container
        Copy systemd service files to /etc/ paths rather than /lib.
        Handle multipath.conf changes during startup and avoid multipath.conf mount(RKE limitation)
    Testing: tested on 1.15 and 1.16 and verified pod creation, volume mounts work fine. Planning to run
    complete integration suite before merge.
    Review: gcostea, rkumar, sbyadarahalli
    Bug: https://nimblejira.nimblestorage.com/browse/NLT-
    Signed-off-by: Shiva Krishna, Merla shivakrishna.merla@hpe.com

Signed-off-by: Shiva Krishna, Merla <shivakrishna.merla@hpe.com>