### PR TITLE
csi-driver: misc fixes related to nodeinfo updates

### DIFF
--- a/cmd/csi-driver/Dockerfile
+++ b/cmd/csi-driver/Dockerfile
@@ -1,4 +1,7 @@
-FROM registry.access.redhat.com/ubi7/ubi-init:7.7-18.1575996389
+FROM registry.access.redhat.com/ubi7/ubi-minimal:7.7-238
+
+RUN microdnf update -y && rm -rf /var/cache/yum
+RUN microdnf install -y systemd
 
 LABEL name="HPE CSI Driver for Kubernetes" \
       maintainer="HPE Storage" \

--- a/cmd/csi-driver/csi-driver.go
+++ b/cmd/csi-driver/csi-driver.go
@@ -148,7 +148,7 @@ func csiCliHandler(cmd *cobra.Command) error {
 		syscall.SIGTERM)
 
 	s := <-stop
-	log.Fatalf("Exiting due to signal [%v] notification for pid [%d]", s.String(), pid)
+	log.Infof("Exiting due to signal [%v] notification for pid [%d]", s.String(), pid)
 	d.Stop(nodeService)
 	log.Infof("Stopped [%d]", pid)
 	return nil

--- a/pkg/flavor/kubernetes/flavor.go
+++ b/pkg/flavor/kubernetes/flavor.go
@@ -171,7 +171,7 @@ func (flavor *Flavor) LoadNodeInfo(node *model.Node) (string, error) {
 			nodeInfo.Spec.Networks = networksFromNode
 			updateNodeRequired = true
 		}
-		// update node FC port WWPN's on mismatch
+		// update node FC port WWPNs on mismatch
 		wwpnsFromNode := getWwpnsFromNode(node)
 		if !reflect.DeepEqual(nodeInfo.Spec.WWPNs, wwpnsFromNode) {
 			nodeInfo.Spec.WWPNs = wwpnsFromNode

--- a/pkg/flavor/kubernetes/flavor.go
+++ b/pkg/flavor/kubernetes/flavor.go
@@ -134,29 +134,50 @@ func (flavor *Flavor) LoadNodeInfo(node *model.Node) (string, error) {
 
 	nodeInfo, err := flavor.getNodeInfoByUUID(node.UUID)
 	if err != nil {
-		log.Errorf("Error obtaining node info by uuid - %s\n", err.Error())
+		log.Errorf("Error obtaining node info by uuid %s- %s\n", node.UUID, err.Error())
 		return "", err
 	}
 
+	if nodeInfo == nil {
+		nodeInfo, err = flavor.getNodeInfoByName(node.Name)
+		if err != nil {
+			log.Errorf("Error obtaining node info by name %s- %s\n", node.Name, err.Error())
+			return "", err
+		}
+	}
+
 	if nodeInfo != nil {
+		// update nodename for lookup during cleanup(unload)
+		flavor.nodeName = nodeInfo.ObjectMeta.Name
+
 		log.Infof("Node info %s already known to cluster\n", nodeInfo.ObjectMeta.Name)
 		// make sure the nodeInfo has updated information from the host
 		updateNodeRequired := false
+
+		// update node uuid on mismatch
+		if nodeInfo.Spec.UUID != node.UUID {
+			nodeInfo.Spec.UUID = node.UUID
+			updateNodeRequired = true
+		}
+		// update node initiator IQNs on mismatch
 		iqnsFromNode := getIqnsFromNode(node)
 		if !reflect.DeepEqual(nodeInfo.Spec.IQNs, iqnsFromNode) {
 			nodeInfo.Spec.IQNs = iqnsFromNode
 			updateNodeRequired = true
 		}
+		// update node network information on mismatch
 		networksFromNode := getNetworksFromNode(node)
 		if !reflect.DeepEqual(nodeInfo.Spec.Networks, networksFromNode) {
 			nodeInfo.Spec.Networks = networksFromNode
 			updateNodeRequired = true
 		}
+		// update node FC port WWPN's on mismatch
 		wwpnsFromNode := getWwpnsFromNode(node)
 		if !reflect.DeepEqual(nodeInfo.Spec.WWPNs, wwpnsFromNode) {
 			nodeInfo.Spec.WWPNs = wwpnsFromNode
 			updateNodeRequired = true
 		}
+
 		if !updateNodeRequired {
 			// no update needed to existing CRD
 			return node.UUID, nil
@@ -169,19 +190,6 @@ func (flavor *Flavor) LoadNodeInfo(node *model.Node) (string, error) {
 			return "", err
 		}
 	} else {
-		// lookup the HPENodeInfo by name. In case of hard reset, CRDs still exist and we have new nodeID
-		nodeInfo, err := flavor.getNodeInfoByName(node.Name)
-		if nodeInfo != nil {
-			// patch the existing HpeNodeInfo with updated nodeID
-			log.Infof("updating Node %s from old UUID %s to new %s", nodeInfo.Name, nodeInfo.Spec.UUID, node.UUID)
-			nodeInfo.Spec.UUID = node.UUID
-			updatedNodeInfo, err := flavor.crdClient.StorageV1().HPENodeInfos().Update(nodeInfo)
-			if err != nil {
-				log.Errorf("Error updating the node %s - %s\n", nodeInfo.Name, err.Error())
-				return "", err
-			}
-			return updatedNodeInfo.Spec.UUID, nil
-		}
 		// if we didn't find HPENodeInfo yet, create one.
 		newNodeInfo := &crd_v1.HPENodeInfo{
 			ObjectMeta: meta_v1.ObjectMeta{
@@ -204,8 +212,9 @@ func (flavor *Flavor) LoadNodeInfo(node *model.Node) (string, error) {
 			return "", nil
 		}
 
-		log.Infof("Successfully added node info for node %v", nodeInfo)
+		// update nodename for lookup during cleanup(unload)
 		flavor.nodeName = nodeInfo.ObjectMeta.Name
+		log.Infof("Successfully added node info for node %v", nodeInfo)
 	}
 
 	return node.UUID, nil


### PR DESCRIPTION
* Problem:
  * nodeinfo resources are not cleaned up as log.Fatalf was used before unload.
  * ubi-init images doesn't receive signal on kill
  * on node-name re-use, stale nodeinfo resources are re-used as well
* Implementation:
  * change log.Fatalf to Infof so we just log it but not exit.
  * change base images to ubi-minimal which works well in all platforms.
  * update nodeinfo properties on node name re-use and stale hpenodeinfo objects.
* Testing: tested scenarios of creation/deletion/IQN updates. node scale up/down by Fred.
* Review: gcostea, rkumar, sbyadarahalli
Signed-off-by: Shiva Krishna, Merla <shivakrishna.merla@hpe.com>