### PR TITLE
csi-driver: misc fixes related to nodeinfo updates (#109)

### DIFF
--- a/cmd/csi-driver/csi-driver.go
+++ b/cmd/csi-driver/csi-driver.go
@@ -148,7 +148,7 @@ func csiCliHandler(cmd *cobra.Command) error {
 		syscall.SIGTERM)
 
 	s := <-stop
-	log.Fatalf("Exiting due to signal [%v] notification for pid [%d]", s.String(), pid)
+	log.Infof("Exiting due to signal [%v] notification for pid [%d]", s.String(), pid)
 	d.Stop(nodeService)
 	log.Infof("Stopped [%d]", pid)
 	return nil


### PR DESCRIPTION
* csi-driver: misc fixes related to nodeinfo updates
* Problem:
  * nodeinfo resources are not cleaned up as log.Fatalf was used before unload.
  * on node-name re-use, stale nodeinfo resources are re-used as well
* Implementation:
  * change log.Fatalf to Infof so we just log it but not exit.
  * update nodeinfo properties on node name re-use and stale hpenodeinfo objects.
* Testing: tested scenarios of creation/deletion/IQN updates. node scale up/down by Fred.
* Review: gcostea, rkumar, sbyadarahalli
Signed-off-by: Shiva Krishna, Merla <shivakrishna.merla@hpe.com>