### PR TITLE
Fixed bug CON-693

### DIFF
--- a/pkg/driver/controller_server.go
+++ b/pkg/driver/controller_server.go
@@ -430,9 +430,7 @@ func (driver *Driver) createVolume(
 
 	// Create volume using pre-populated content if requested
 	if volumeContentSource != nil {
-		log.Tracef("Request with volumeContentSource: %+v", volumeContentSource)
-
-		// Verify source snap if specified
+		log.Tracef("Request with volumeContentSource: %+v", volumeContentSource) // Verify source snap if specified
 		if volumeContentSource.GetSnapshot() != nil {
 			// Check if the driver supports SNAPSHOT service
 			if !driver.IsSupportedControllerCapability(csi.ControllerServiceCapability_RPC_CREATE_DELETE_SNAPSHOT) {
@@ -457,6 +455,32 @@ func (driver *Driver) createVolume(
 				return nil, status.Error(codes.Internal, "Parent volume ID is missing in the snapshot response")
 			}
 
+			// Get the parent volume from the snapshot
+			existingParentVolume, err := storageProvider.GetVolume(existingSnap.VolumeID)
+			if err != nil {
+				log.Error("err: ", err.Error())
+				return nil,
+					status.Error(codes.Internal,
+						fmt.Sprintf("Failed to check if snapshot's parent volume %s with ID %s exist, err: %s",
+							existingSnap.VolumeName, existingSnap.VolumeID, err.Error()))
+			}
+
+			// Get existing volume device info
+			parentVolFsType, err := driver.flavor.GetVolumePropertyOfPV("fsType", existingParentVolume.Name)
+			if err != nil {
+				log.Error("err: ", err.Error())
+				return nil,
+					status.Error(codes.Internal,
+						fmt.Sprintf("Failed to check if filesystme exists on the %s parent volume, err: %s",
+							existingSnap.VolumeName, err.Error()))
+			}
+
+			// Check if requested filesystem for a clone volume is same as existing snapshot
+			if filesystem != parentVolFsType {
+				return nil,
+					status.Error(codes.InvalidArgument,
+						fmt.Sprintf("Requested volume filesystem %s cannot be different than snapshot's parent volume filesystem %s", filesystem, parentVolFsType))
+			}
 			// Create a clone from another volume
 			log.Infof("About to create a new clone '%s' from snapshot %s with options %+v", name, existingSnap.ID, createOptions)
 			volume, err := storageProvider.CloneVolume(name, description, "", existingSnap.ID, size, createOptions)

--- a/pkg/driver/controller_server.go
+++ b/pkg/driver/controller_server.go
@@ -465,6 +465,13 @@ func (driver *Driver) createVolume(
 							existingSnap.VolumeName, existingSnap.VolumeID, err.Error()))
 			}
 
+			if existingParentVolume == nil {
+				return nil,
+					status.Error(codes.NotFound,
+						fmt.Sprintf("Could not find Snapshot's parent volume %s with ID %s",
+							existingSnap.VolumeName, existingSnap.VolumeID))
+
+			}
 			// Get existing parent volume fsType attribute
 			parentVolFsType, err := driver.flavor.GetVolumePropertyOfPV("fsType", existingParentVolume.Name)
 			if err != nil {

--- a/pkg/driver/controller_server.go
+++ b/pkg/driver/controller_server.go
@@ -471,7 +471,7 @@ func (driver *Driver) createVolume(
 				log.Error("err: ", err.Error())
 				return nil,
 					status.Error(codes.Internal,
-						fmt.Sprintf("Failed to check if filesystme exists on the %s parent volume, err: %s",
+						fmt.Sprintf("Failed to check if filesystem exists on the %s parent volume, err: %s",
 							existingSnap.VolumeName, err.Error()))
 			}
 

--- a/pkg/driver/controller_server.go
+++ b/pkg/driver/controller_server.go
@@ -465,7 +465,7 @@ func (driver *Driver) createVolume(
 							existingSnap.VolumeName, existingSnap.VolumeID, err.Error()))
 			}
 
-			// Get existing volume device info
+			// Get existing parent volume fsType attribute
 			parentVolFsType, err := driver.flavor.GetVolumePropertyOfPV("fsType", existingParentVolume.Name)
 			if err != nil {
 				log.Error("err: ", err.Error())

--- a/pkg/flavor/kubernetes/flavor.go
+++ b/pkg/flavor/kubernetes/flavor.go
@@ -606,5 +606,5 @@ func (flavor *Flavor) GetVolumePropertyOfPV(propertyName string, pvName string) 
 	if propertyVal, found := volAttr[propertyName]; found {
 		return propertyVal, nil
 	}
-	return "", fmt.Errorf("unable to retrieve attribute %s of the pv %s : not found", propertyName, pvName)
+	return "", nil
 }

--- a/pkg/flavor/kubernetes/flavor.go
+++ b/pkg/flavor/kubernetes/flavor.go
@@ -590,3 +590,21 @@ func (flavor *Flavor) GetCredentialsFromPodSpec(volumeHandle string, podName str
 	}
 	return nil, fmt.Errorf("Pod %s/%s does not contain the volume %s", namespace, podName, volumeHandle)
 }
+
+// GetFsTypeOfPvName retrieves volume filesystem for a given CSI volname
+func (flavor *Flavor) GetVolumePropertyOfPV(propertyName string, pvName string) (string, error) {
+	log.Infof(">>>>> GetVolumePropertyOfPV, pvName: %s, propertyName: %s", pvName, propertyName)
+	defer log.Infof("<<<<< GetVolumePropertyOfPV")
+
+	pv, err := flavor.kubeClient.CoreV1().PersistentVolumes().Get(pvName, meta_v1.GetOptions{})
+	if err != nil {
+		log.Errorf("Error retrieving the attribtue %s of the pv %s, err: %v", propertyName, pvName, err.Error())
+		return "", err
+	}
+	volAttr := pv.Spec.CSI.VolumeAttributes
+
+	if propertyVal, found := volAttr[propertyName]; found {
+		return propertyVal, nil
+	}
+	return "", fmt.Errorf("unable to retrieve attribute %s of the pv %s : not found", propertyName, pvName)
+}

--- a/pkg/flavor/types.go
+++ b/pkg/flavor/types.go
@@ -29,4 +29,5 @@ type Flavor interface {
 	DeleteNFSVolume(pvName string) error
 	HandleNFSNodePublish(request *csi.NodePublishVolumeRequest) (*csi.NodePublishVolumeResponse, error)
 	IsNFSVolume(volumeID string) bool
+	GetVolumePropertyOfPV(propertyName string, pvName string) (string, error)
 }

--- a/pkg/flavor/vanilla/flavor.go
+++ b/pkg/flavor/vanilla/flavor.go
@@ -68,3 +68,6 @@ func (flavor *Flavor) HandleNFSNodePublish(request *csi.NodePublishVolumeRequest
 func (flavor *Flavor) IsNFSVolume(volumeID string) bool {
 	return false
 }
+func (flavor *Flavor) GetVolumePropertyOfPV(propertyName string, pvName string) (string, error) {
+	return "", nil
+}


### PR DESCRIPTION
Problem: 
PVC creation should error out if filesystem type of child In storage class definition is different from parent PVC

Fix:
Added a logic to fetch the parent volume filesystem type and compare it with the requested pvc filesystem, error out if they are different. 

