### PR TITLE
allow unpublish to go through on dead node

### DIFF
--- a/pkg/driver/controller_server.go
+++ b/pkg/driver/controller_server.go
@@ -905,12 +905,6 @@ func (driver *Driver) controllerUnpublishVolume(volumeID string, nodeID string, 
 		return nil
 	}
 
-	// Decode and get node details
-	node, err := driver.flavor.GetNodeInfo(nodeID)
-	if err != nil {
-		return status.Error(codes.Aborted, err.Error())
-	}
-
 	// Get Storage Provider
 	storageProvider, err := driver.GetStorageProvider(secrets)
 	if err != nil {
@@ -929,13 +923,15 @@ func (driver *Driver) controllerUnpublishVolume(volumeID string, nodeID string, 
 		return err
 	}
 
+	// pass the nodeID to the container storage provider and do not do a look up of the node object as
+	// node object may have been deleted as part of UnloadNodeInfo when the node went down
 	if !existingVolume.Published {
-		log.Infof("Volume %s is already unpublished from node %s", existingVolume.Name, node.Name)
+		log.Infof("Volume %s is already unpublished from node with ID %s", existingVolume.Name, nodeID)
 		return nil
 	}
 
 	// Remove ACL from the volume based on the requested Node ID
-	err = storageProvider.UnpublishVolume(existingVolume.ID, node.UUID)
+	err = storageProvider.UnpublishVolume(existingVolume.ID, nodeID)
 	if err != nil {
 		log.Trace("err: ", err.Error())
 		return status.Error(codes.Aborted,


### PR DESCRIPTION
* Problem:
 unpublish fails when GetNodeID is invoked on a dead node
for which the hpe node info was removed
* Implementation:
  ignore node object lookup for unpublish
* Testing:
tested with node down scenario and making sure the va is deleted
```
CSI Driver Logs
time="2020-03-03T01:47:09Z" level=info msg="GRPC call: /csi.v1.Controller/ControllerUnpublishVolume" file="utils.go:63"

 kube-controller-manager Logs
{"log":"W0303 01:47:09.333984       1 reconciler.go:232] attacherDetacher.DetachVolume started for volume \"pvc-e23752b1-1196-49bd-bb96-77aa8843fd0f\" (UniqueName: \"kubernetes.io/csi/csi.hpe.com^06434baa972e6e4919000000000000000000001280\") on node \"hiqa-rhel6\" This volume is not safe to detach, but maxWaitForUnmountDuration 6m0s expired, force detaching\n","stream":"stderr","time":"2020-03-03T01:47:09.334133463Z"}
{"log":"I0303 01:47:10.175861       1 operation_generator.go:526] DetachVolume.Detach succeeded for volume \"pvc-e23752b1-1196-49bd-bb96-77aa8843fd0f\" (UniqueName: \"kubernetes.io/csi/csi.hpe.com^06434baa972e6e4919000000000000000000001280\") on node \"hiqa-rhel6\" \n","stream":"stderr","time":"2020-03-03T01:47:10.176039435Z"}
```
* Bug: https://nimblejira.nimblestorage.com/browse/CON-720