### PR TITLE
 handle case when clone volume already exists

### DIFF
--- a/pkg/driver/controller_server.go
+++ b/pkg/driver/controller_server.go
@@ -411,14 +411,6 @@ func (driver *Driver) createVolume(
 					name, existingVolume.Size, size))
 		}
 
-		// Check if the source content is being requested.
-		if volumeContentSource != nil {
-			log.Tracef("Requested volumeContentSource, %+v", volumeContentSource)
-			return nil, status.Error(
-				codes.AlreadyExists,
-				fmt.Sprintf("Volume %s already exists, but the source content is being requested", name))
-		}
-
 		// Return existing volume with volume context info
 		log.Tracef("Returning the existing volume '%s' with size %d", existingVolume.Name, existingVolume.Size)
 		return &csi.Volume{


### PR DESCRIPTION
* Problem:
 we see sometime context timeout errors without
errors in csp , consequent create clone volume fails with
error volume already exists, but the source content is being requested
* Implementation:
limit and report the above error only if we find the clone volume exists
but is associated to a different volume
* Testing:
* Bug: https://nimblejira.nimblestorage.com/browse/CON-743