### PR TITLE
fix hostname for log collection

### DIFF
--- a/cmd/csi-driver/diag/hpe-logcollector.sh
+++ b/cmd/csi-driver/diag/hpe-logcollector.sh
@@ -22,7 +22,7 @@
 log_collection() {
 # Initializing the file and directory
 timestamp=`date '+%Y%m%d_%H%M%S'`
-hostname=`hostname -s`
+hostname=$(cat /etc/hostname)
 filename="hpe-storage-logs-$hostname-$timestamp.tar.gz"
 
 destinationDir="/var/log/tmp"


### PR DESCRIPTION
* Problem:
- hostname utility not present in the ubi minimal image
* Implementation:
- since host networking is mapped to the container,
rely on /etc/hostname
* Testing:
* Bug: https://nimblejira.nimblestorage.com/browse/CON-729