### PR TITLE
csi-driver: update rescan script to avoid missing utilities

### DIFF
--- a/cmd/csi-driver/rescan-scsi-bus.sh
+++ b/cmd/csi-driver/rescan-scsi-bus.sh
@@ -811,7 +811,7 @@ findmultipath()
   local mp2=
 
   # Need a sdev, and executable multipath and dmsetup command here
-  if [ -z "$dev" ] || [ ! -x $DMSETUP ] ; then
+  if [ -z "$dev" ] ; then
     return 1
   fi
 
@@ -833,10 +833,6 @@ findmultipath()
 reloadmpaths()
 {
   local mpath
-  if [ ! -x $MULTIPATH ] ; then
-    echo "no -x multipath"
-    return
-  fi
 
   if [ "$1" = "1" ] ; then
     echo "Reloading all multipath devices"
@@ -1087,9 +1083,9 @@ if test -w /sys/module/scsi_mod/parameters/default_dev_flags -a $scan_flags != 0
     unset OLD_SCANFLAGS
   fi
 fi
-DMSETUP=$(which dmsetup)
+DMSETUP=dmsetup
 [ -z "$DMSETUP" ] && flush= && mp_enable=
-MULTIPATH=$(which multipath)
+MULTIPATH=multipath
 [ -z "$MULTIPATH" ] && flush= && mp_enable=
 
 echo -n "Scanning SCSI subsystem for new devices"


### PR DESCRIPTION
* Problem:
  * `which` command is not available within container, so failing
  * to reload multipath table after device resize. This caused
  * intermittent fs resize failures as we later use "multipathd reconfigure"
  * which can take a while in background before we get to fsresize.
* Implementation:
  * Fix script to invoke multipath -r after resize is done.
* Testing: tested resize on Ubuntu 18.04 and CentOS 7.6.
* Review: gcostea, rkumar
* Bug: https://nimblejira.nimblestorage.com/browse/CON-747
Signed-off-by: Shiva Krishna, Merla <shivakrishna.merla@hpe.com>