### PR TITLE
ephemeral volume, make accessProtocol mandatory

### DIFF
--- a/examples/kubernetes/pod-inline-with-vol-secrets.yaml
+++ b/examples/kubernetes/pod-inline-with-vol-secrets.yaml
@@ -20,4 +20,5 @@ spec:
          csi.storage.k8s.io/ephemeral: "true"
          inline-volume-secret-name: nimble-secret
          inline-volume-secret-namespace: kube-system
+         accessProtocol: "iscsi"
          size: "7Gi"

--- a/examples/kubernetes/pod-inline.yaml
+++ b/examples/kubernetes/pod-inline.yaml
@@ -20,4 +20,5 @@ spec:
        fsType: ext3
        volumeAttributes:
          csi.storage.k8s.io/ephemeral: "true"
+         accessProtocol: "iscsi"
          size: "5Gi"

--- a/pkg/driver/node_server.go
+++ b/pkg/driver/node_server.go
@@ -1099,6 +1099,14 @@ func (driver *Driver) nodePublishEphemeralVolume(
 		log.Tracef("Ephemeral volume %s requested with size %s (%v)", volumeName, sizeStr, sizeInBytes)
 	}
 
+	// make accessProtocol mandatory for inline volume
+	_, ok := volumeContext["accessProtocol"]
+	if !ok {
+		return status.Error(codes.Internal,
+			fmt.Sprintf("accessProtocol is required. Failed to create ephemeral volume %s",
+				volumeName))
+	}
+
 	// Construct volume capabitilities to pass to createVolume()
 	volCapabilities := []*csi.VolumeCapability{
 		volumeCapability,


### PR DESCRIPTION
* Problem:
 generic error Failed to get storage provider from secrets, No secrets have been provided
* Implementation:
 prevent ephemeral volume creation if accessProtocol is not specified
* Testing:
* Bug: https://nimblejira.nimblestorage.com/browse/CON-862

Signed-off-by: Raunak Kumar <rkumar@nimblestorage.com>