### PR TITLE
Report volume limits per node with GetNodeInfo configured with deployment

### DIFF
--- a/pkg/driver/constants.go
+++ b/pkg/driver/constants.go
@@ -83,4 +83,8 @@ const (
 	nfsResourcesKey = "nfsResources"
 	// indicates if this is an underlying NFS PVC(not exposed to user)
 	nfsPVCKey = "nfsPVC"
+
+	// Maximum default number of volumes that controller can publish to the node.
+	defaultMaxVolPerNode = 100
+	maxVolumesPerNodeKey = "MAX_VOLUMES_PER_NODE"
 )

--- a/pkg/driver/node_server.go
+++ b/pkg/driver/node_server.go
@@ -35,10 +35,6 @@ var (
 	ephemeralUnpublishLock sync.Mutex
 )
 
-// Maximum default number of volumes that controller can publish to the node.
-const defaultMaxVolPerNode = 100
-const maxVolumePerNodeKey = "MAX_VOLUMES_PER_NODE"
-
 // Helper utility to construct default mountpoint path
 func getDefaultMountPoint(id string) string {
 	return fmt.Sprintf("%s/%s", defaultMountDir, id)
@@ -1614,13 +1610,13 @@ func (driver *Driver) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoReque
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 	// Get max volume per node from environment variable
-	nodeMaxVolumesLimit := driver.nodeGetIntEnv(maxVolumePerNodeKey)
+	nodeMaxVolumesLimit := driver.nodeGetIntEnv(maxVolumesPerNodeKey)
 
 	// Maximum number of volumes that controller can publish to the node.
-  	// If value is not set or zero CO SHALL decide how many volumes of
-  	// this type can be published by the controller to the node. The
-  	// plugin MUST NOT set negative values here.
- 	// This field is OPTIONAL.
+	// If value is not set or zero CO SHALL decide how many volumes of
+	// this type can be published by the controller to the node. The
+	// plugin MUST NOT set negative values here.
+	// This field is OPTIONAL.
 	if nodeMaxVolumesLimit <= 0 {
 		nodeMaxVolumesLimit = defaultMaxVolPerNode
 	}
@@ -1643,7 +1639,6 @@ func (driver *Driver) nodeGetIntEnv(envKey string) int64 {
 	if err != nil {
 		log.Warnf("Failed to read cluster node %s setting. Error: %s", envKey, err.Error())
 		return 0
-
 	}
 	return val
 }


### PR DESCRIPTION
Feature: CSI Volume Limit 
Requirement : 
To support volume limits in a CSI driver, the plugin must fill in max_volumes_per_node in NodeGetInfoResponse. 

Implementations:
k8s cluster node supports max_volume_per_node though, this property should be advertised by Node driver during NodeGetInfoResponse. The CSI driver implementation will use node env 
variable MAX_VOLUME_PER_NODE if this is set by the user during deployment. If user doesn't set , default value 100 Volume Limit will be used by the CSI driver. 

Example : 
  - name: hpe-csi-driver
          image: dcs-docker.sjcartifactory.eng.nimblestorage.com/hpestorage/csi-driver:vsingh_priv
          args :
            - "--endpoint=$(CSI_ENDPOINT)"
            - "--node-service"
            - "--flavor=kubernetes"
          env:
            - name: CSI_ENDPOINT
              value: unix:///csi/csi.sock
            - name: LOG_LEVEL
              value: trace
            - name: MAX_VOLUMES_PER_NODE
              value: "20"