### PR TITLE
csi-driver: Fix overrides comparision to be case sensitive

### DIFF
--- a/pkg/flavor/kubernetes/flavor.go
+++ b/pkg/flavor/kubernetes/flavor.go
@@ -396,7 +396,7 @@ func (flavor *Flavor) getClaimOverrideOptions(claim *v1.PersistentVolumeClaim, o
 	provisionerName := provisioner
 	for _, override := range overrides {
 		for key, annotation := range claim.Annotations {
-			if strings.HasPrefix(strings.ToLower(key), provisionerName+"/"+strings.ToLower(override)) {
+			if strings.HasPrefix(key, provisionerName+"/"+override) {
 				if valOpt, ok := optionsMap[override]; ok {
 					if override == "size" || override == "sizeInGiB" {
 						// do not allow  override of size and sizeInGiB


### PR DESCRIPTION
* Problem:
  * While checking for PVC overrides, we convert key, value to lowercase
  * causing duplicate entries if there is a mismatch between sc param and override param.
  * eg. sc param, limitIops and allowOverrides containing limitIOPS leads to both params
  * to get added to map.
* Implementation:
  * Fix comparision to be case sensitive while fetching PVC overrides
* Testing: tested with incorrect values to make sure only correct params are included.
* Review: gcostea, rkumar
* Bug: https://nimblejira.nimblestorage.com/browse/NLT-
Signed-off-by: Shiva Krishna, Merla <shivakrishna.merla@hpe.com>