### PR TITLE
csi-driver: cleanup code for cloneOfPVC

### DIFF
--- a/examples/kubernetes/hpe-nimble-storage/README.md
+++ b/examples/kubernetes/hpe-nimble-storage/README.md
@@ -52,7 +52,7 @@ These parameters are applicable only for Pod inline volumes and to be specified 
 **Note:** The `NodePublishSecretRef` and (`inline-volume-secret-name`, `inline-volume-secret-namespace`) are mutually exclusive. One of them must be specified for ephemeral inline volume.
 
 ### Cloning parameters
-Cloning supports two modes of cloning. Either use `cloneOf` and reference a PVC in the current namespace or use `importVolAsClone` and reference a Nimble volume name to clone and import to Kubernetes.
+Cloning supports two modes of cloning. Either use `cloneOf` and reference a PV of an existing PVC or use `importVolAsClone` and reference a Nimble volume name to clone and import to Kubernetes.
 
 | Parameter | String | Description |
 | --------- | ------ | ----------- |

--- a/pkg/flavor/kubernetes/flavor.go
+++ b/pkg/flavor/kubernetes/flavor.go
@@ -411,43 +411,11 @@ func (flavor *Flavor) getClaimOverrideOptions(claim *v1.PersistentVolumeClaim, o
 		}
 	}
 
-	// check to see if there is cloneOfPVC annotation present
-	volumeName, err := flavor.getPVFromPVCAnnotation(claim, provisioner)
-	if err != nil {
-		return nil, err
-	}
-
-	// update the options map with the pv name if there is one
-	if volumeName != "" {
-		optionsMap[cloneOf] = volumeName
-	}
-
 	// make sure cloneOfPVC is removed from the options (all cases)
 	if _, found := optionsMap[cloneOfPVC]; found {
 		delete(optionsMap, cloneOfPVC)
 	}
 	return optionsMap, nil
-}
-
-func (flavor *Flavor) getPVFromPVCAnnotation(claim *v1.PersistentVolumeClaim, provisioner string) (string, error) {
-	log.Tracef(">>>>> getPVFromPVCAnnotation for %s", provisioner)
-	defer log.Trace("<<<<< getPVFromPVCAnnotation")
-
-	// check to see if we have the cloneOfPVC annotation
-	pvcToClone, foundClonePVC := claim.Annotations[fmt.Sprintf("%s%s", provisioner, cloneOfPVC)]
-	if !foundClonePVC {
-		return "", nil
-	}
-
-	pvName, err := flavor.getVolumeNameFromClaimName(pvcToClone)
-	log.Infof("pvc %s maps to pv %s", pvcToClone, pvName)
-	if err != nil {
-		return "", fmt.Errorf("unable to retrieve pvc %s : %s", pvcToClone, err.Error())
-	}
-	if pvName == "" {
-		return "", fmt.Errorf("unable to retrieve pvc %s : not found", pvcToClone)
-	}
-	return pvName, nil
 }
 
 // MetaUIDFunc is an IndexFunc used to cache PVCs by their UID

--- a/pkg/flavor/kubernetes/flavor.go
+++ b/pkg/flavor/kubernetes/flavor.go
@@ -32,7 +32,6 @@ import (
 const (
 	allowOverrides = "allowOverrides"
 	cloneOf        = "cloneOf"
-	cloneOfPVC     = "cloneOfPVC"
 )
 
 var (
@@ -411,10 +410,6 @@ func (flavor *Flavor) getClaimOverrideOptions(claim *v1.PersistentVolumeClaim, o
 		}
 	}
 
-	// make sure cloneOfPVC is removed from the options (all cases)
-	if _, found := optionsMap[cloneOfPVC]; found {
-		delete(optionsMap, cloneOfPVC)
-	}
 	return optionsMap, nil
 }
 


### PR DESCRIPTION
* Problem:
  * Currently cloneOfPVC assumes PV as an input and confusing
  * with cloneOf parameter.
* Implementation:
  * Deprecate and cleanup of cloneOfPVC option in favor of cloneOf
  * which refers to source PV to clone from.
* Testing: tested with cloneOf to make sure for no regressions.
* Review: gcostea, rkumar
* Bug: https://nimblejira.nimblestorage.com/browse/NLT-
Signed-off-by: Shiva Krishna, Merla <shivakrishna.merla@hpe.com>