### PR TITLE
csi-driver: use node name from the podSpec to create hpenodeinfo objects

### DIFF
--- a/pkg/flavor/kubernetes/flavor.go
+++ b/pkg/flavor/kubernetes/flavor.go
@@ -130,6 +130,11 @@ func (flavor *Flavor) LoadNodeInfo(node *model.Node) (string, error) {
 	log.Tracef(">>>>> LoadNodeInfo called with node %v", node)
 	defer log.Trace("<<<<< LoadNodeInfo")
 
+	// overwrite actual host name with node name from k8s to be compliant
+	if name := os.Getenv("NODE_NAME"); name != "" {
+		node.Name = name
+	}
+
 	nodeInfo, err := flavor.getNodeInfoByUUID(node.UUID)
 	if err != nil {
 		log.Errorf("Error obtaining node info by uuid %s- %s\n", node.UUID, err.Error())
@@ -206,8 +211,7 @@ func (flavor *Flavor) LoadNodeInfo(node *model.Node) (string, error) {
 		log.Infof("Adding node with name %s", node.Name)
 		nodeInfo, err = flavor.crdClient.StorageV1().HPENodeInfos().Create(newNodeInfo)
 		if err != nil {
-			log.Infof("Error adding node %v - %s", nodeInfo, err.Error())
-			return "", nil
+			log.Fatalf("Error adding node %v - %s", nodeInfo, err.Error())
 		}
 
 		// update nodename for lookup during cleanup(unload)


### PR DESCRIPTION
* Problem:
  * Currently CSI node driver is creating hpenodeinfos object with name of the
  * underlying host which might not follow k8s object naming conventions. This will
  * fail if hostname has uppercase letters. But kubelet seems to convert them to lowercase to join
  * them to cluster.
* Implementation:
  * Use NODE_NAME env populated with pod fields to consider as object name for hpenodeinfos type.
  * For upgrades, even if underlying hostname differs with spec.nodeName, we will continue to use
  * already created one. For new ones, we use spec.nodeName.
* Testing: tested with deploying node plugin with changes.
* Review: gcostea, rkumar
Signed-off-by: Shiva Krishna, Merla <shivakrishna.merla@hpe.com>