### PR TITLE
Require iscsi or multipath but do not fail in absence of one

### DIFF
--- a/cmd/csi-driver/Dockerfile
+++ b/cmd/csi-driver/Dockerfile
@@ -61,4 +61,7 @@ ADD [ "csi-driver", "/bin/" ]
 ADD [ "conform/entrypoint.sh", "/entrypoint.sh" ]
 RUN [ "chmod", "+x", "/entrypoint.sh" ]
 
+# add plugin binary
+ADD [ "csi-driver", "/bin/" ]
+
 ENTRYPOINT [ "/entrypoint.sh" ]

--- a/cmd/csi-driver/LICENSE
+++ b/cmd/csi-driver/LICENSE
@@ -1,0 +1,192 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and
+distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright
+owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities
+that control, are controlled by, or are under common control with that entity.
+For the purposes of this definition, "control" means (i) the power, direct or
+indirect, to cause the direction or management of such entity, whether by
+contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the
+outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising
+permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including
+but not limited to software source code, documentation source, and
+configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation or
+translation of a Source form, including but not limited to compiled object
+code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form,
+made available under the License, as indicated by a copyright notice that is
+included in or attached to the work (an example is provided in the Appendix
+below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that
+is based on (or derived from) the Work and for which the editorial revisions,
+annotations, elaborations, or other modifications represent, as a whole, an
+original work of authorship. For the purposes of this License, Derivative Works
+shall not include works that remain separable from, or merely link (or bind by
+name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original
+version of the Work and any modifications or additions to that Work or
+Derivative Works thereof, that is intentionally submitted to Licensor for
+inclusion in the Work by the copyright owner or by an individual or Legal
+Entity authorized to submit on behalf of the copyright owner. For the purposes
+of this definition, "submitted" means any form of electronic, verbal, or
+written communication sent to the Licensor or its representatives, including
+but not limited to communication on electronic mailing lists, source code
+control systems, and issue tracking systems that are managed by, or on behalf
+of, the Licensor for the purpose of discussing and improving the Work, but
+excluding communication that is conspicuously marked or otherwise designated in
+writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf
+of whom a Contribution has been received by Licensor and subsequently
+incorporated within the Work.
+
+2. Grant of Copyright License.
+
+Subject to the terms and conditions of this License, each Contributor hereby
+grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable copyright license to reproduce, prepare Derivative Works of,
+publicly display, publicly perform, sublicense, and distribute the Work and
+such Derivative Works in Source or Object form.
+
+3. Grant of Patent License.
+
+Subject to the terms and conditions of this License, each Contributor hereby
+grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable (except as stated in this section) patent license to make, have
+made, use, offer to sell, sell, import, and otherwise transfer the Work, where
+such license applies only to those patent claims licensable by such Contributor
+that are necessarily infringed by their Contribution(s) alone or by combination
+of their Contribution(s) with the Work to which such Contribution(s) was
+submitted. If You institute patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Work or a
+Contribution incorporated within the Work constitutes direct or contributory
+patent infringement, then any patent licenses granted to You under this License
+for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution.
+
+You may reproduce and distribute copies of the Work or Derivative Works thereof
+in any medium, with or without modifications, and in Source or Object form,
+provided that You meet the following conditions:
+
+You must give any other recipients of the Work or Derivative Works a copy of
+this License; and
+You must cause any modified files to carry prominent notices stating that You
+changed the files; and
+You must retain, in the Source form of any Derivative Works that You
+distribute, all copyright, patent, trademark, and attribution notices from the
+Source form of the Work, excluding those notices that do not pertain to any
+part of the Derivative Works; and
+If the Work includes a "NOTICE" text file as part of its distribution, then any
+Derivative Works that You distribute must include a readable copy of the
+attribution notices contained within such NOTICE file, excluding those notices
+that do not pertain to any part of the Derivative Works, in at least one of the
+following places: within a NOTICE text file distributed as part of the
+Derivative Works; within the Source form or documentation, if provided along
+with the Derivative Works; or, within a display generated by the Derivative
+Works, if and wherever such third-party notices normally appear. The contents
+of the NOTICE file are for informational purposes only and do not modify the
+License. You may add Your own attribution notices within Derivative Works that
+You distribute, alongside or as an addendum to the NOTICE text from the Work,
+provided that such additional attribution notices cannot be construed as
+modifying the License.
+You may add Your own copyright statement to Your modifications and may provide
+additional or different license terms and conditions for use, reproduction, or
+distribution of Your modifications, or for any such Derivative Works as a
+whole, provided Your use, reproduction, and distribution of the Work otherwise
+complies with the conditions stated in this License.
+
+5. Submission of Contributions.
+
+Unless You explicitly state otherwise, any Contribution intentionally submitted
+for inclusion in the Work by You to the Licensor shall be under the terms and
+conditions of this License, without any additional terms or conditions.
+Notwithstanding the above, nothing herein shall supersede or modify the terms
+of any separate license agreement you may have executed with Licensor regarding
+such Contributions.
+
+6. Trademarks.
+
+This License does not grant permission to use the trade names, trademarks,
+service marks, or product names of the Licensor, except as required for
+reasonable and customary use in describing the origin of the Work and
+reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty.
+
+Unless required by applicable law or agreed to in writing, Licensor provides
+the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
+including, without limitation, any warranties or conditions of TITLE,
+NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are
+solely responsible for determining the appropriateness of using or
+redistributing the Work and assume any risks associated with Your exercise of
+permissions under this License.
+
+8. Limitation of Liability.
+
+In no event and under no legal theory, whether in tort (including negligence),
+contract, or otherwise, unless required by applicable law (such as deliberate
+and grossly negligent acts) or agreed to in writing, shall any Contributor be
+liable to You for damages, including any direct, indirect, special, incidental,
+or consequential damages of any character arising as a result of this License
+or out of the use or inability to use the Work (including but not limited to
+damages for loss of goodwill, work stoppage, computer failure or malfunction,
+or any and all other commercial damages or losses), even if such Contributor
+has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability.
+
+While redistributing the Work or Derivative Works thereof, You may choose to
+offer, and charge a fee for, acceptance of support, warranty, indemnity, or
+other liability obligations and/or rights consistent with this License.
+However, in accepting such obligations, You may act only on Your own behalf and
+on Your sole responsibility, not on behalf of any other Contributor, and only
+if You agree to indemnify, defend, and hold each Contributor harmless for any
+liability incurred by, or claims asserted against, such Contributor by reason
+of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work
+
+To apply the Apache License to your work, attach the following boilerplate
+notice, with the fields enclosed by brackets "[]" replaced with your own
+identifying information. (Don't include the brackets!) The text should be
+enclosed in the appropriate comment syntax for the file format. We also
+recommend that a file or class name and description of purpose be included on
+the same "printed page" as the copyright notice for easier identification
+within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/cmd/csi-driver/tune/99-nimble-tune.rules
+++ b/cmd/csi-driver/tune/99-nimble-tune.rules
@@ -1,0 +1,36 @@
+##
+# Copyright 2019 Hewlett Packard Enterprise Development LP.
+#
+##
+ACTION!="add|change", GOTO="nimble_tuning_end"
+SUBSYSTEM!="block", GOTO="nimble_tuning_end"
+KERNEL!="sd*|dm-*", GOTO="nimble_tuning_end"
+KERNEL=="dm-*", ENV{DM_UUID}!="*6c9ce9*", GOTO="nimble_tuning_end"
+ENV{DEVTYPE}=="partition", GOTO="nimble_tuning_end"
+
+#Comment the below line to enable these rules for devices attached to VM as VMDK disks
+KERNEL=="sd*", ENV{ID_SERIAL}!="*6c9ce9*", GOTO="nimble_tuning_end"
+#Uncommend the below line to enable these rules for devices attached to VM as VMDK disks
+#KERNEL=="sd*", ENV{ID_SERIAL}!="*6c9ce9*", ENV{ID_VENDOR}!="VMware", GOTO="nimble_tuning_end"
+
+# Below rules are to assist in easily setting block device configurations
+# suiting user application needs.
+# Please uncomment the lines beginning with ATTR to enable these rules
+# and run "udevadm control --reload-rules" and "udevadm trigger" to apply for all Nimble devices.
+
+# set max_sectors_kb to max_hw_sectors_kb.
+ATTR{queue/max_sectors_kb}="4096"
+# set read_ahead_kb to 128
+ATTR{queue/read_ahead_kb}="128"
+# set nr_requests to 512.
+ATTR{queue/nr_requests}="512"
+# set scheduler to noop.
+ATTR{queue/scheduler}="noop"
+# disable add_random.
+ATTR{queue/add_random}="0"
+# disable rotational.
+ATTR{queue/rotational}="0"
+# set rq_affinity to 2.
+ATTR{queue/rq_affinity}="2"
+
+LABEL="nimble_tuning_end"

--- a/cmd/csi-driver/tune/cloud_vm_config.json
+++ b/cmd/csi-driver/tune/cloud_vm_config.json
@@ -1,0 +1,231 @@
+[
+    {
+        "category": "filesystem",
+        "severity": "info",
+        "description": "Enable discard option to allow auto space reclamation using UNMAP",
+        "parameter": "discard",
+        "recommendation": "enabled"
+    },
+    {
+        "category": "filesystem",
+        "severity": "warning",
+        "description": "Enable _netdev for iSCSI mount devices to allow network to be up before mounting device",
+        "parameter": "_netdev",
+        "recommendation": "enabled"
+    },
+    {
+        "category": "filesystem",
+        "severity": "info",
+        "description": "Enable nobarrier to allow write barriers on SSD drives",
+        "parameter": "nobarrier",
+        "recommendation": "enabled"
+    },
+    {
+        "category": "disk",
+        "severity": "warning",
+        "description": "Reduce latency by disabling contribution to randomness entroy pool for disk operations. Can be tuned by UDEV using 99-nimble-tune.rules",
+        "parameter": "add_random",
+        "recommendation": "0"
+    },
+    {
+        "category": "disk",
+        "severity": "warning",
+        "description": "Request affinity of 2 is recommended to allow I/O completions on different CPU than submission CPU. Can be tuned by UDEV using 99-nimble-tune.rules",
+        "parameter": "rq_affinity",
+        "recommendation": "2"
+    },
+    {
+        "category": "disk",
+        "severity": "warning",
+        "description": "Scheduler noop is recommended to remove I/O request sorting overhead for SSD disks. Can be tuned by UDEV using 99-nimble-tune.rules",
+        "parameter": "scheduler",
+        "recommendation": "noop"
+    },
+    {
+        "category": "disk",
+        "severity": "warning",
+        "description": "Set rotational to 0 to indicate SSD disks. Can be tuned by UDEV using 99-nimble-tune.rules",
+        "parameter": "rotational",
+        "recommendation": "0"
+    },
+    {
+        "category": "disk",
+        "severity": "warning",
+        "description": "Set minimum I/O request allocations to 512. Can be tuned by UDEV using 99-nimble-tune.rules",
+        "parameter": "nr_requests",
+        "recommendation": "512"
+    },
+    {
+        "category": "disk",
+        "severity": "warning",
+        "description": "Set maximum I/O request size to 4MB in case of sequential I/O. Can be tuned by UDEV using 99-nimble-tune.rules",
+        "parameter": "max_sectors_kb",
+        "recommendation": "4096"
+    },
+    {
+        "category": "iscsi",
+        "severity": "warning",
+        "description": "Automatically startup and login to all discovered sessions during system reboot. Can be set in /etc/iscsi/iscsid.conf",
+        "parameter": "startup",
+        "recommendation": "automatic"
+    },
+    {
+        "category": "iscsi",
+        "severity": "warning",
+        "description": "Replacement_timeout of 10 seconds is recommended for faster failover of I/O by multipath on path failures. Can be set in /etc/iscsi/iscsid.conf",
+        "parameter": "replacement_timeout",
+        "recommendation": "10"
+    },
+    {
+        "category": "iscsi",
+        "severity": "warning",
+        "description": "Minimum login timeout of 15 seconds is recommended with iSCSI. Can be set in /etc/iscsi/iscsid.conf",
+        "parameter": "login_timeout",
+        "recommendation": "15"
+    },
+    {
+        "category": "iscsi",
+        "severity": "warning",
+        "description": "Minimum timeout of 10 seconds is recommended with noop requests. Can be set in /etc/iscsi/iscsid.conf",
+        "parameter": "noop_out_timeout",
+        "recommendation": "10"
+    },
+    {
+        "category": "iscsi",
+        "severity": "info",
+        "description": "Minimum cmds_max of 256 is recommended for each session if handling multiple LUN's. Can be set in /etc/iscsi/iscsid.conf",
+        "parameter": "cmds_max",
+        "recommendation": "256"
+    },
+    {
+        "category": "iscsi",
+        "severity": "warning",
+        "description": "Minimum queue_depth of 64 is recommended for each iSCSI session/path. Can be set in /etc/iscsi/iscsid.conf",
+        "parameter": "queue_depth",
+        "recommendation": "64"
+    },
+    {
+        "category": "iscsi",
+        "severity": "info",
+        "description": "Minimum number of sessions per iSCSI login is recommended to be 1 by default. If additional sessions are needed this can be set in /etc/iscsi/iscsid.conf. If NCM is running, please change min_session_per_array in /etc/ncm.conf and restart nlt service instead",
+        "parameter": "nr_sessions",
+        "recommendation": "4"
+    },
+    {
+        "category": "multipath",
+        "severity": "critical",
+        "description": "product attribute recommended to be set to Server in /etc/multipath.conf",
+        "parameter": "product",
+        "recommendation": "\"Server\""
+    },
+    {
+        "category": "multipath",
+        "severity": "critical",
+        "description": "alua prioritizer is recommended. Can be set in /etc/multipath.conf",
+        "parameter": "prio",
+        "recommendation": "alua"
+    },
+    {
+        "category": "multipath",
+        "severity": "critical",
+        "description": "scsi_dh_alua device handler is recommended. Can be set in /etc/multipath.conf",
+        "parameter": "hardware_handler",
+        "recommendation": "\"1 alua\""
+    },
+    {
+        "category": "multipath",
+        "severity": "warning",
+        "description": "immediate failback setting is recommended. Can be set in /etc/multipath.conf",
+        "parameter": "failback",
+        "recommendation": "immediate"
+    },
+    {
+        "category": "multipath",
+        "severity": "critical",
+        "description": "immediately fail i/o on transient path failures to retry on other paths, value=1. Can be set in /etc/multipath.conf",
+        "parameter": "fast_io_fail_tmo",
+        "recommendation": "5"
+    },
+    {
+        "category": "multipath",
+        "severity": "critical",
+        "description": "queueing is recommended for 150 seconds, with no_path_retry value of 30. Can be set in /etc/multipath.conf",
+        "parameter": "no_path_retry",
+        "recommendation": "30"
+    },
+    {
+        "category": "multipath",
+        "severity": "warning",
+        "description": "service-time path selector is recommended. Can be set in /etc/multipath.conf",
+        "parameter": "path_selector",
+        "recommendation": "\"service-time 0\""
+    },
+    {
+        "category": "multipath",
+        "severity": "critical",
+        "description": "vendor attribute recommended to be set to Nimble in /etc/multipath.conf",
+        "parameter": "vendor",
+        "recommendation": "\"Nimble\""
+    },
+    {
+        "category": "multipath",
+        "severity": "critical",
+        "description": "group paths according to ALUA path priority of active/standby. Recommended to be set to group_by_prio in /etc/multipath.conf",
+        "parameter": "path_grouping_policy",
+        "recommendation": "group_by_prio"
+    },
+    {
+        "category": "multipath",
+        "severity": "critical",
+        "description": "tur path checker is recommended. Can be set in /etc/multipath.conf",
+        "parameter": "path_checker",
+        "recommendation": "tur"
+    },
+    {
+        "category": "multipath",
+        "severity": "critical",
+        "description": "infinite value is recommended for timeout in cases of device loss for FC. Can be set in /etc/multipath.conf",
+        "parameter": "dev_loss_tmo",
+        "recommendation": "infinity"
+    },
+    {
+        "category": "fc",
+        "severity": "warning",
+        "description": "Minimum queue_depth of 128 is recommended for Qlogic drivers. Set using modprobe.conf, rebuild initramfs and reboot system.",
+        "parameter": "ql2xmaxqdepth",
+        "recommendation": "64",
+        "driver": "qla2xxx"
+    },
+    {
+        "category": "fc",
+        "severity": "warning",
+        "description": "Minimum LUN queue_depth of 128 is recommended for Emulex drivers. Set using modprobe.conf, rebuild initramfs and reboot system.",
+        "parameter": "lpfc_lun_queue_depth",
+        "recommendation": "64",
+        "driver": "lpfc"
+    },
+    {
+        "category": "fc",
+        "severity": "warning",
+        "description": "Minimum HBA queue_depth of 8192 is recommended for Emulex drivers. Set using modprobe.conf, rebuild initramfs and reboot system.",
+        "parameter": "lpfc_hba_queue_depth",
+        "recommendation": "8192",
+        "driver": "lpfc"
+    },
+    {
+        "category": "fc",
+        "severity": "warning",
+        "description": "Minimum LUN queue_depth of 64 is recommended for Cisco FC drivers. Set using modprobe.conf, rebuild initramfs and reboot system.",
+        "parameter": "fnic_max_qdepth",
+        "recommendation": "64",
+        "driver": "fnic"
+    },
+    {
+        "category": "fc",
+        "severity": "warning",
+        "description": "Minimum LUN queue_depth of 64 is recommended for Brocade FC drivers. Set using modprobe.conf, rebuild initramfs and reboot system.",
+        "parameter": "bfa_lun_queue_depth",
+        "recommendation": "64",
+        "driver": "bfa"
+    }
+]

--- a/cmd/csi-driver/tune/config.json
+++ b/cmd/csi-driver/tune/config.json
@@ -1,0 +1,238 @@
+[
+    {
+        "category": "filesystem",
+        "severity": "info",
+        "description": "Enable discard option to allow auto space reclamation using UNMAP",
+        "parameter": "discard",
+        "recommendation": "enabled"
+    },
+    {
+        "category": "filesystem",
+        "severity": "warning",
+        "description": "Enable _netdev for iSCSI mount devices to allow network to be up before mounting device",
+        "parameter": "_netdev",
+        "recommendation": "enabled"
+    },
+    {
+        "category": "filesystem",
+        "severity": "info",
+        "description": "Enable nobarrier to allow write barriers on SSD drives",
+        "parameter": "nobarrier",
+        "recommendation": "enabled"
+    },
+    {
+        "category": "disk",
+        "severity": "warning",
+        "description": "Reduce latency by disabling contribution to randomness entroy pool for disk operations. Can be tuned by UDEV using 99-nimble-tune.rules",
+        "parameter": "add_random",
+        "recommendation": "0"
+    },
+    {
+        "category": "disk",
+        "severity": "warning",
+        "description": "Request affinity of 2 is recommended to allow I/O completions on different CPU than submission CPU. Can be tuned by UDEV using 99-nimble-tune.rules",
+        "parameter": "rq_affinity",
+        "recommendation": "2"
+    },
+    {
+        "category": "disk",
+        "severity": "warning",
+        "description": "Scheduler noop is recommended to remove I/O request sorting overhead for SSD disks. Can be tuned by UDEV using 99-nimble-tune.rules",
+        "parameter": "scheduler",
+        "recommendation": "noop"
+    },
+    {
+        "category": "disk",
+        "severity": "warning",
+        "description": "Set rotational to 0 to indicate SSD disks. Can be tuned by UDEV using 99-nimble-tune.rules",
+        "parameter": "rotational",
+        "recommendation": "0"
+    },
+    {
+        "category": "disk",
+        "severity": "warning",
+        "description": "Set minimum I/O request allocations to 512. Can be tuned by UDEV using 99-nimble-tune.rules",
+        "parameter": "nr_requests",
+        "recommendation": "512"
+    },
+    {
+        "category": "disk",
+        "severity": "warning",
+        "description": "Set maximum I/O request size to 4MB in case of sequential I/O. Can be tuned by UDEV using 99-nimble-tune.rules",
+        "parameter": "max_sectors_kb",
+        "recommendation": "4096"
+    },
+    {
+        "category": "disk",
+        "severity": "warning",
+        "description": "Set the maximum number of kilobytes that the operating system may read ahead during a sequential read operation. Can be tuned by UDEV using 99-nimble-tune.rules",
+        "parameter": "read_ahead_kb",
+        "recommendation": "128"
+    },
+    {
+        "category": "iscsi",
+        "severity": "warning",
+        "description": "Automatically startup and login to all discovered sessions during system reboot. Can be set in /etc/iscsi/iscsid.conf",
+        "parameter": "startup",
+        "recommendation": "automatic"
+    },
+    {
+        "category": "iscsi",
+        "severity": "warning",
+        "description": "Replacement_timeout of 10 seconds is recommended for faster failover of I/O by multipath on path failures. Can be set in /etc/iscsi/iscsid.conf",
+        "parameter": "replacement_timeout",
+        "recommendation": "10"
+    },
+    {
+        "category": "iscsi",
+        "severity": "warning",
+        "description": "Minimum login timeout of 15 seconds is recommended with iSCSI. Can be set in /etc/iscsi/iscsid.conf",
+        "parameter": "login_timeout",
+        "recommendation": "15"
+    },
+    {
+        "category": "iscsi",
+        "severity": "warning",
+        "description": "Minimum timeout of 10 seconds is recommended with noop requests. Can be set in /etc/iscsi/iscsid.conf",
+        "parameter": "noop_out_timeout",
+        "recommendation": "10"
+    },
+    {
+        "category": "iscsi",
+        "severity": "info",
+        "description": "Minimum cmds_max of 256 is recommended for each session if handling multiple LUN's. Can be set in /etc/iscsi/iscsid.conf",
+        "parameter": "cmds_max",
+        "recommendation": "256"
+    },
+    {
+        "category": "iscsi",
+        "severity": "warning",
+        "description": "Minimum queue_depth of 64 is recommended for each iSCSI session/path. Can be set in /etc/iscsi/iscsid.conf",
+        "parameter": "queue_depth",
+        "recommendation": "256"
+    },
+    {
+        "category": "iscsi",
+        "severity": "info",
+        "description": "Minimum number of sessions per iSCSI login is recommended to be 1 by default. If additional sessions are needed this can be set in /etc/iscsi/iscsid.conf. If NCM is running, please change min_session_per_array in /etc/ncm.conf and restart nlt service instead",
+        "parameter": "nr_sessions",
+        "recommendation": "1"
+    },
+    {
+        "category": "multipath",
+        "severity": "critical",
+        "description": "product attribute recommended to be set to Server in /etc/multipath.conf",
+        "parameter": "product",
+        "recommendation": "\"Server\""
+    },
+    {
+        "category": "multipath",
+        "severity": "critical",
+        "description": "alua prioritizer is recommended. Can be set in /etc/multipath.conf",
+        "parameter": "prio",
+        "recommendation": "alua"
+    },
+    {
+        "category": "multipath",
+        "severity": "critical",
+        "description": "scsi_dh_alua device handler is recommended. Can be set in /etc/multipath.conf",
+        "parameter": "hardware_handler",
+        "recommendation": "\"1 alua\""
+    },
+    {
+        "category": "multipath",
+        "severity": "warning",
+        "description": "immediate failback setting is recommended. Can be set in /etc/multipath.conf",
+        "parameter": "failback",
+        "recommendation": "immediate"
+    },
+    {
+        "category": "multipath",
+        "severity": "critical",
+        "description": "immediately fail i/o on transient path failures to retry on other paths, value=1. Can be set in /etc/multipath.conf",
+        "parameter": "fast_io_fail_tmo",
+        "recommendation": "5"
+    },
+    {
+        "category": "multipath",
+        "severity": "critical",
+        "description": "queueing is recommended for 150 seconds, with no_path_retry value of 30. Can be set in /etc/multipath.conf",
+        "parameter": "no_path_retry",
+        "recommendation": "30"
+    },
+    {
+        "category": "multipath",
+        "severity": "warning",
+        "description": "service-time path selector is recommended. Can be set in /etc/multipath.conf",
+        "parameter": "path_selector",
+        "recommendation": "\"service-time 0\""
+    },
+    {
+        "category": "multipath",
+        "severity": "critical",
+        "description": "vendor attribute recommended to be set to Nimble in /etc/multipath.conf",
+        "parameter": "vendor",
+        "recommendation": "\"Nimble\""
+    },
+    {
+        "category": "multipath",
+        "severity": "critical",
+        "description": "group paths according to ALUA path priority of active/standby. Recommended to be set to group_by_prio in /etc/multipath.conf",
+        "parameter": "path_grouping_policy",
+        "recommendation": "group_by_prio"
+    },
+    {
+        "category": "multipath",
+        "severity": "critical",
+        "description": "tur path checker is recommended. Can be set in /etc/multipath.conf",
+        "parameter": "path_checker",
+        "recommendation": "tur"
+    },
+    {
+        "category": "multipath",
+        "severity": "critical",
+        "description": "infinite value is recommended for timeout in cases of device loss for FC. Can be set in /etc/multipath.conf",
+        "parameter": "dev_loss_tmo",
+        "recommendation": "infinity"
+    },
+    {
+        "category": "fc",
+        "severity": "warning",
+        "description": "Minimum queue_depth of 128 is recommended for Qlogic drivers. Set using modprobe.conf, rebuild initramfs and reboot system.",
+        "parameter": "ql2xmaxqdepth",
+        "recommendation": "64",
+        "driver": "qla2xxx"
+    },
+    {
+        "category": "fc",
+        "severity": "warning",
+        "description": "Minimum LUN queue_depth of 128 is recommended for Emulex drivers. Set using modprobe.conf, rebuild initramfs and reboot system.",
+        "parameter": "lpfc_lun_queue_depth",
+        "recommendation": "64",
+        "driver": "lpfc"
+    },
+    {
+        "category": "fc",
+        "severity": "warning",
+        "description": "Minimum HBA queue_depth of 8192 is recommended for Emulex drivers. Set using modprobe.conf, rebuild initramfs and reboot system.",
+        "parameter": "lpfc_hba_queue_depth",
+        "recommendation": "8192",
+        "driver": "lpfc"
+    },
+    {
+        "category": "fc",
+        "severity": "warning",
+        "description": "Minimum LUN queue_depth of 64 is recommended for Cisco FC drivers. Set using modprobe.conf, rebuild initramfs and reboot system.",
+        "parameter": "fnic_max_qdepth",
+        "recommendation": "64",
+        "driver": "fnic"
+    },
+    {
+        "category": "fc",
+        "severity": "warning",
+        "description": "Minimum LUN queue_depth of 64 is recommended for Brocade FC drivers. Set using modprobe.conf, rebuild initramfs and reboot system.",
+        "parameter": "bfa_lun_queue_depth",
+        "recommendation": "64",
+        "driver": "bfa"
+    }
+]

--- a/cmd/csi-driver/tune/empty.go
+++ b/cmd/csi-driver/tune/empty.go
@@ -1,0 +1,2 @@
+// Empty go file hack to get go modules to pull this directory	
+package empty

--- a/cmd/csi-driver/tune/multipath.conf.generic
+++ b/cmd/csi-driver/tune/multipath.conf.generic
@@ -1,0 +1,39 @@
+defaults {
+    user_friendly_names yes
+    find_multipaths     no
+}
+blacklist {
+    devnode "^(ram|raw|loop|fd|md|dm-|sr|scd|st)[0-9]*"
+    devnode "^hd[a-z]"
+    device {
+        vendor  ".*"
+        product ".*"
+    }
+}
+blacklist_exceptions {
+    device {
+        vendor  "Nimble"
+        product "Server"
+    }
+    device {
+        vendor  "3PARdata"
+        product "VV"
+    }
+}
+devices {
+    device {
+        vendor               "Nimble"
+        product              "Server"
+        hardware_handler     "1 alua"
+        path_checker         tur
+        rr_weight            uniform
+        rr_min_io_rq         1
+        dev_loss_tmo         infinity
+        fast_io_fail_tmo     5
+        no_path_retry        30
+        path_selector        "service-time 0"
+        path_grouping_policy group_by_prio
+        prio                 alua
+        failback             immediate
+    }
+}

--- a/cmd/csi-driver/tune/multipath.conf.upstream
+++ b/cmd/csi-driver/tune/multipath.conf.upstream
@@ -1,0 +1,41 @@
+defaults {
+    user_friendly_names yes
+    find_multipaths     no
+    uxsock_timeout      10000
+}
+blacklist {
+    devnode "^(ram|raw|loop|fd|md|dm-|sr|scd|st)[0-9]*"
+    devnode "^hd[a-z]"
+    device {
+        vendor  ".*"
+        product ".*"
+    }
+}
+blacklist_exceptions {
+    property "(ID_WWN|SCSI_IDENT_.*|ID_SERIAL)"
+    device {
+        vendor  "Nimble"
+        product "Server"
+    }
+    device {
+        vendor  "3PARdata"
+        product "VV"
+    }
+}
+devices {
+    device {
+        vendor               "Nimble"
+        product              "Server"
+        hardware_handler     "1 alua"
+        path_checker         tur
+        rr_weight            uniform
+        rr_min_io_rq         1
+        dev_loss_tmo         infinity
+        fast_io_fail_tmo     5
+        no_path_retry        30
+        path_selector        "service-time 0"
+        path_grouping_policy group_by_prio
+        prio                 alua
+        failback             immediate
+    }
+}


### PR DESCRIPTION
There can be situations where iscsi or multipath are not available. It is better not to fail on that scenarios thant requiring to have both in the OS.