### PR TITLE
nfs: add service account while deploying nfs pod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway v1.12.0 // indirect
 	github.com/hashicorp/golang-lru v0.5.3 // indirect
-	github.com/hpe-storage/common-host-libs v0.0.0-20200508185915-bfa59fed1059
+	github.com/hpe-storage/common-host-libs v0.0.0-20200511215010-0799fec94a72
 	github.com/hpe-storage/k8s-custom-resources v0.0.0-20190828052325-42886f48215c
 	github.com/jonboulle/clockwork v0.1.0 // indirect
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -163,6 +163,8 @@ github.com/hpe-storage/common-host-libs v0.0.0-20200507161320-98ce16843504 h1:Bu
 github.com/hpe-storage/common-host-libs v0.0.0-20200507161320-98ce16843504/go.mod h1:qQxvwt4l9C79p2V8bY1P13As1+ylyznKJVp3K2P5bz8=
 github.com/hpe-storage/common-host-libs v0.0.0-20200508185915-bfa59fed1059 h1:njPFFQLxUhvUxmOYBTsdCPLIj5NyRhcynkM13BlvA6g=
 github.com/hpe-storage/common-host-libs v0.0.0-20200508185915-bfa59fed1059/go.mod h1:qQxvwt4l9C79p2V8bY1P13As1+ylyznKJVp3K2P5bz8=
+github.com/hpe-storage/common-host-libs v0.0.0-20200511215010-0799fec94a72 h1:E5oaJ11r2IU5CBfTfzOX+ZmJa5e8Qs7siNVIhJO3UVk=
+github.com/hpe-storage/common-host-libs v0.0.0-20200511215010-0799fec94a72/go.mod h1:qQxvwt4l9C79p2V8bY1P13As1+ylyznKJVp3K2P5bz8=
 github.com/hpe-storage/k8s-custom-resources v0.0.0-20190828052325-42886f48215c h1:M/4pHhSouEEjd613SFODOskZmn6pS5tWITHdA8MPWMI=
 github.com/hpe-storage/k8s-custom-resources v0.0.0-20190828052325-42886f48215c/go.mod h1:qYST/Hepa2MRB85zskShx/+WlbUG5bmq/orhy6sA2jE=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=

--- a/pkg/flavor/types.go
+++ b/pkg/flavor/types.go
@@ -34,6 +34,5 @@ type Flavor interface {
 	IsNFSVolume(volumeID string) bool
 	GetVolumePropertyOfPV(propertyName string, pvName string) (string, error)
 	GetNFSVolumeID(volumeID string) (string, error)
-	CreateNFSConfigMap(nfsNamespace string) error
 	GetOrchestratorVersion() (*version.Info, error)
 }

--- a/pkg/flavor/vanilla/flavor.go
+++ b/pkg/flavor/vanilla/flavor.go
@@ -82,10 +82,6 @@ func (flavor *Flavor) GetNFSVolumeID(volumeID string) (string, error) {
 	return "", nil
 }
 
-func (flavor *Flavor) CreateNFSConfigMap(nfsNamespace string) error {
-	return nil
-}
-
 func (flavor *Flavor) GetOrchestratorVersion() (*version.Info, error) {
 	return nil, nil
 }

--- a/vendor/github.com/hpe-storage/common-host-libs/linux/os.go
+++ b/vendor/github.com/hpe-storage/common-host-libs/linux/os.go
@@ -69,16 +69,6 @@ var OsIscsiPackageMap = map[string]string{
 	OsTypeAmazon: iscsiInitiatorUtils,
 }
 
-// OsIscsiServiceMap provides mapping of os distribution to iscsi service name
-var OsIscsiServiceMap = map[string]string{
-	OsTypeUbuntu: iscsid,
-	OsTypeSuse:   iscsid,
-	OsTypeRedhat: iscsid,
-	OsTypeCentos: iscsid,
-	OsTypeOracle: iscsid,
-	OsTypeAmazon: iscsid,
-}
-
 var osInfo *OsInfo
 var osInfoLock sync.Mutex
 
@@ -498,7 +488,7 @@ func EnableService(serviceType string) (err error) {
 func enableSystemdService(osInfo *OsInfo, serviceType string) (err error) {
 	var serviceName string
 	if serviceType == iscsi {
-		serviceName = OsIscsiServiceMap[osInfo.GetOsDistro()]
+		serviceName = "iscsid.service"
 	} else if serviceType == multipath {
 		serviceName = "multipathd.service"
 	} else {
@@ -555,8 +545,8 @@ func enableInitVService(osInfo *OsInfo, serviceType string) (err error) {
 func enableUbuntuService(osInfo *OsInfo, serviceType string) (err error) {
 	var serviceName string
 	if serviceType == iscsi {
-		// get distro specific iscsi service name
-		serviceName = OsIscsiServiceMap[osInfo.GetOsDistro()]
+		// generic for all distros
+		serviceName = iscsid
 	} else if serviceType == multipath {
 		// generic for all distros
 		serviceName = multipathd
@@ -634,7 +624,7 @@ func getServiceCommandArgs(osInfo *OsInfo, packageType string, operation string)
 			// suse 11.* has open-iscsi and 12.* has iscsid
 			args = append(args, openIscsi)
 		} else {
-			args = append(args, OsIscsiServiceMap[osInfo.GetOsDistro()])
+			args = append(args, iscsid)
 		}
 	}
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -72,7 +72,7 @@ github.com/hpcloud/tail/ratelimiter
 github.com/hpcloud/tail/util
 github.com/hpcloud/tail/watch
 github.com/hpcloud/tail/winfile
-# github.com/hpe-storage/common-host-libs v0.0.0-20200508185915-bfa59fed1059
+# github.com/hpe-storage/common-host-libs v0.0.0-20200511215010-0799fec94a72
 github.com/hpe-storage/common-host-libs/chapi
 github.com/hpe-storage/common-host-libs/concurrent
 github.com/hpe-storage/common-host-libs/connectivity


### PR DESCRIPTION
* Problem:
  * On openshift need to add securitycontextconstraint with serviceaccount
  * to allow creation of NFS pods just like CSI pods
* Implementation:
  * Add a method to create service account in namespace where we deploy NFS PVC/Pod.
  * cleanup method names as we don't need to export k8s specific methods outside of flavor package.
* Testing: added unit tests, tested on both OCP and K8s to verify service account, NFS pod deployment.
* Review: gcostea, rkumar
Signed-off-by: Shiva Krishna, Merla <shivakrishna.merla@hpe.com>