### PR TITLE
nfs: add conformance checks for nfs  packages

### DIFF
--- a/cmd/csi-driver/conform/hpe-storage-node.sh
+++ b/cmd/csi-driver/conform/hpe-storage-node.sh
@@ -3,7 +3,7 @@
 exit_on_error() {
     exit_code=$1
     if [ $exit_code -ne 0 ]; then
-        >&2 echo "command failed with exit code ${exit_code}."
+        echo "command failed with exit code ${exit_code}."
         exit $exit_code
     fi
 }
@@ -46,9 +46,9 @@ if [ "$CONFORM_TO" = "ubuntu" ]; then
     if [ ! -f /sbin/mount.nfs4 ]; then
         apt-get -qq update
         apt-get -qq install -y nfs-common
-        exit_on_error $?
         systemctl enable nfs-utils.service
         systemctl start nfs-utils.service
+        exit_on_error $?
     fi
 
 elif [ "$CONFORM_TO" = "redhat" ]; then
@@ -68,9 +68,9 @@ elif [ "$CONFORM_TO" = "redhat" ]; then
     # Install nfs client packages
     if [ ! -f /sbin/mount.nfs4 ]; then
         yum -y install nfs-utils
-        exit_on_error $?
         systemctl enable nfs-utils.service
         systemctl start nfs-utils.service
+        exit_on_error $?
     fi
 elif [ "$CONFORM_TO" = "coreos" ]; then
     echo "skipping package checks/installation on CoreOS"

--- a/cmd/csi-driver/conform/hpe-storage-node.sh
+++ b/cmd/csi-driver/conform/hpe-storage-node.sh
@@ -42,6 +42,7 @@ if [ "$CONFORM_TO" = "ubuntu" ]; then
         exit 1
     fi
 
+    # Install nfs client packages
     if [ ! -f /sbin/mount.nfs4 ]; then
         apt-get -qq update
         apt-get -qq install -y nfs-common
@@ -64,7 +65,7 @@ elif [ "$CONFORM_TO" = "redhat" ]; then
         exit 1
     fi
 
-    # Install device-mapper-multipath
+    # Install nfs client packages
     if [ ! -f /sbin/mount.nfs4 ]; then
         yum -y install nfs-utils
         exit_on_error $?


### PR DESCRIPTION
* Problem:
  * nfs-utils/nfs-common packages are not always present on node
* Implementation:
  * On redhat/centos versions check for nfs-utils package
  * On Ubuntu check for nfs-common package
  * enable NFS client services on node(nfs-utils.service on both redhat/ubuntu)
  * For CoreOS skip all installation as they are immutable.
* Testing: verified running the script on both redhat and ubuntu
* Review: gcostea, rkumar, sbyadarahalli
Signed-off-by: Shiva Krishna, Merla <shivakrishna.merla@hpe.com>