### PR TITLE
nfs: misc nfs fixes

### DIFF
--- a/cmd/csi-driver/Dockerfile
+++ b/cmd/csi-driver/Dockerfile
@@ -1,7 +1,7 @@
 FROM registry.access.redhat.com/ubi7/ubi-minimal:7.7-238
 
 RUN microdnf update -y && rm -rf /var/cache/yum
-RUN microdnf install -y systemd hostname
+RUN microdnf install -y systemd
 
 LABEL name="HPE CSI Driver for Kubernetes" \
       maintainer="HPE Storage" \
@@ -37,7 +37,8 @@ RUN ln -s /chroot/chroot-host-wrapper.sh /chroot/blkid \
     && ln -s /chroot/chroot-host-wrapper.sh /chroot/multipathd \
     && ln -s /chroot/chroot-host-wrapper.sh /chroot/umount \
     && ln -s /chroot/chroot-host-wrapper.sh /chroot/ip \
-    && ln -s /chroot/chroot-host-wrapper.sh /chroot/dmidecode
+    && ln -s /chroot/chroot-host-wrapper.sh /chroot/dmidecode \
+    && ln -s /chroot/chroot-host-wrapper.sh /chroot/dnsdomainname
 
 ENV PATH="/chroot:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 

--- a/cmd/csi-driver/Dockerfile
+++ b/cmd/csi-driver/Dockerfile
@@ -1,7 +1,7 @@
 FROM registry.access.redhat.com/ubi7/ubi-minimal:7.7-238
 
 RUN microdnf update -y && rm -rf /var/cache/yum
-RUN microdnf install -y systemd
+RUN microdnf install -y systemd hostname
 
 LABEL name="HPE CSI Driver for Kubernetes" \
       maintainer="HPE Storage" \

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway v1.12.0 // indirect
 	github.com/hashicorp/golang-lru v0.5.3 // indirect
-	github.com/hpe-storage/common-host-libs v0.0.0-20200516064614-43272f9d4d33
+	github.com/hpe-storage/common-host-libs v0.0.0-20200520064700-5130e102775b
 	github.com/hpe-storage/k8s-custom-resources v0.0.0-20190828052325-42886f48215c
 	github.com/jonboulle/clockwork v0.1.0 // indirect
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -169,6 +169,7 @@ github.com/hpe-storage/common-host-libs v0.0.0-20200516064614-43272f9d4d33 h1:RA
 github.com/hpe-storage/common-host-libs v0.0.0-20200516064614-43272f9d4d33/go.mod h1:qQxvwt4l9C79p2V8bY1P13As1+ylyznKJVp3K2P5bz8=
 github.com/hpe-storage/common-host-libs v0.0.0-20200520064700-5130e102775b h1:bh17qfxG4hWzrzvACOmrSpcUvPLdmwCJ3SiASsYHlIA=
 github.com/hpe-storage/common-host-libs v0.0.0-20200520064700-5130e102775b/go.mod h1:qQxvwt4l9C79p2V8bY1P13As1+ylyznKJVp3K2P5bz8=
+github.com/hpe-storage/common-host-libs v4.1.0+incompatible h1:NCjBLmpM5P6sXqjvN/Fy5+Lz2HV2HA4F6G81PwjLd9E=
 github.com/hpe-storage/k8s-custom-resources v0.0.0-20190828052325-42886f48215c h1:M/4pHhSouEEjd613SFODOskZmn6pS5tWITHdA8MPWMI=
 github.com/hpe-storage/k8s-custom-resources v0.0.0-20190828052325-42886f48215c/go.mod h1:qYST/Hepa2MRB85zskShx/+WlbUG5bmq/orhy6sA2jE=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=

--- a/go.sum
+++ b/go.sum
@@ -167,6 +167,8 @@ github.com/hpe-storage/common-host-libs v0.0.0-20200515233718-b394acac9ee2 h1:Ye
 github.com/hpe-storage/common-host-libs v0.0.0-20200515233718-b394acac9ee2/go.mod h1:qQxvwt4l9C79p2V8bY1P13As1+ylyznKJVp3K2P5bz8=
 github.com/hpe-storage/common-host-libs v0.0.0-20200516064614-43272f9d4d33 h1:RA1OGcbFtAkOT+uBJ6HDAL3ZZGmYrQHUlq3CN3HeYgI=
 github.com/hpe-storage/common-host-libs v0.0.0-20200516064614-43272f9d4d33/go.mod h1:qQxvwt4l9C79p2V8bY1P13As1+ylyznKJVp3K2P5bz8=
+github.com/hpe-storage/common-host-libs v0.0.0-20200520064700-5130e102775b h1:bh17qfxG4hWzrzvACOmrSpcUvPLdmwCJ3SiASsYHlIA=
+github.com/hpe-storage/common-host-libs v0.0.0-20200520064700-5130e102775b/go.mod h1:qQxvwt4l9C79p2V8bY1P13As1+ylyznKJVp3K2P5bz8=
 github.com/hpe-storage/k8s-custom-resources v0.0.0-20190828052325-42886f48215c h1:M/4pHhSouEEjd613SFODOskZmn6pS5tWITHdA8MPWMI=
 github.com/hpe-storage/k8s-custom-resources v0.0.0-20190828052325-42886f48215c/go.mod h1:qYST/Hepa2MRB85zskShx/+WlbUG5bmq/orhy6sA2jE=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=

--- a/pkg/driver/controller_server.go
+++ b/pkg/driver/controller_server.go
@@ -309,7 +309,7 @@ func (driver *Driver) createVolume(
 			return nil, status.Error(codes.InvalidArgument, "NFS volume provisioning is not supported with block access type")
 		}
 
-		volume, rollback, err := driver.flavor.CreateNFSVolume(driver.chapiDriver, name, size, createParameters, volumeContentSource)
+		volume, rollback, err := driver.flavor.CreateNFSVolume(name, size, createParameters, volumeContentSource)
 		if err == nil {
 			// Return multi-node volume
 			return volume, nil

--- a/pkg/driver/controller_server.go
+++ b/pkg/driver/controller_server.go
@@ -309,7 +309,7 @@ func (driver *Driver) createVolume(
 			return nil, status.Error(codes.InvalidArgument, "NFS volume provisioning is not supported with block access type")
 		}
 
-		volume, rollback, err := driver.flavor.CreateNFSVolume(name, size, createParameters, volumeContentSource)
+		volume, rollback, err := driver.flavor.CreateNFSVolume(driver.chapiDriver, name, size, createParameters, volumeContentSource)
 		if err == nil {
 			// Return multi-node volume
 			return volume, nil

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -66,7 +66,7 @@ func NewDriver(name, version, endpoint, flavorName string, nodeService bool, dbS
 
 	// Configure flavor
 	if flavorName == flavor.Kubernetes {
-		flavor, err := kubernetes.NewKubernetesFlavor(nodeService)
+		flavor, err := kubernetes.NewKubernetesFlavor(nodeService, driver.chapiDriver)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/driver/node_server.go
+++ b/pkg/driver/node_server.go
@@ -703,7 +703,7 @@ func (driver *Driver) NodePublishVolume(ctx context.Context, request *csi.NodePu
 	// Check if volume is requested with NFS resources and intercept here
 	if driver.IsNFSResourceRequest(request.VolumeContext) {
 		log.Infof("NodePublish requested with NFS resources for %s", request.VolumeId)
-		return driver.flavor.HandleNFSNodePublish(driver.chapiDriver, request)
+		return driver.flavor.HandleNFSNodePublish(request)
 	}
 
 	// If ephemeral volume request, then create new volume, add ACL and NodeStage/NodePublish

--- a/pkg/flavor/kubernetes/nfs.go
+++ b/pkg/flavor/kubernetes/nfs.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
-	"github.com/hpe-storage/common-host-libs/chapi"
 	log "github.com/hpe-storage/common-host-libs/logger"
 	"golang.org/x/mod/semver"
 	"google.golang.org/grpc/codes"
@@ -368,8 +367,7 @@ func (flavor *Flavor) HandleNFSNodePublish(req *csi.NodePublishVolumeRequest) (*
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
-	chapiDriver := &chapi.LinuxDriver{}
-	if err := chapiDriver.MountNFSVolume(source, target, mountOptions, "nfs4"); err != nil {
+	if err := flavor.chapiDriver.MountNFSVolume(source, target, mountOptions, "nfs4"); err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 	return &csi.NodePublishVolumeResponse{}, nil
@@ -411,8 +409,7 @@ func (flavor *Flavor) getNFSHostDomain() (string, error) {
 	defer log.Tracef("<<<<< getNFSHostDomain")
 
 	// obtain an array of  {hostname, domainname}
-	chapiDriver := &chapi.LinuxDriver{}
-	hostNameAndDomain, err := chapiDriver.GetHostNameAndDomain()
+	hostNameAndDomain, err := flavor.chapiDriver.GetHostNameAndDomain()
 	if err != nil {
 		return "", fmt.Errorf("Failed to obtain host name and domain to provision NFS volume, %s", err.Error())
 	}

--- a/pkg/flavor/kubernetes/nfs.go
+++ b/pkg/flavor/kubernetes/nfs.go
@@ -27,8 +27,6 @@ const (
 	defaultNFSNamespace = "hpe-nfs"
 	defaultNFSImage     = "hpestorage/nfs-provisioner:2.8.3-4"
 
-	deletionInterval           = 30 // 60s with sleep interval of 2s
-	deletionDelay              = 2 * time.Second
 	creationInterval           = 60 // 120s with sleep interval of 2s
 	creationDelay              = 2 * time.Second
 	defaultExportPath          = "/export"
@@ -60,7 +58,7 @@ type NFSSpec struct {
 }
 
 // CreateNFSVolume creates nfs volume abstracting underlying nfs pvc, deployment and service
-func (flavor *Flavor) CreateNFSVolume(pvName string, reqVolSize int64, parameters map[string]string, volumeContentSource *csi.VolumeContentSource) (nfsVolume *csi.Volume, rollback bool, err error) {
+func (flavor *Flavor) CreateNFSVolume(chapiDriver chapi.Driver, pvName string, reqVolSize int64, parameters map[string]string, volumeContentSource *csi.VolumeContentSource) (nfsVolume *csi.Volume, rollback bool, err error) {
 	log.Tracef(">>>>> CreateNFSVolume with %s", pvName)
 	defer log.Tracef("<<<<< CreateNFSVolume")
 
@@ -113,8 +111,17 @@ func (flavor *Flavor) CreateNFSVolume(pvName string, reqVolSize int64, parameter
 		return nil, true, err
 	}
 
+	// obtain an array of  {hostname, domainname}
+	hostNameAndDomain, err := chapiDriver.GetHostNameAndDomain()
+	if err != nil {
+		return nil, true, fmt.Errorf("Failed to obtain host name and domain to provision NFS volume, %s", err.Error())
+	}
+	if len(hostNameAndDomain) != 2 || hostNameAndDomain[1] == "unknown" {
+		return nil, true, fmt.Errorf("Unable to obtain host domain name to provision NFS volume %s", pvName)
+	}
+	log.Tracef("Host domain name obtained as %s", hostNameAndDomain[1])
 	// create nfs configmap
-	err = flavor.createNFSConfigMap(nfsResourceNamespace)
+	err = flavor.createNFSConfigMap(nfsResourceNamespace, hostNameAndDomain[1])
 	if err != nil {
 		flavor.eventRecorder.Event(claim, core_v1.EventTypeWarning, "ProvisionStorage", err.Error())
 		return nil, true, err
@@ -179,32 +186,15 @@ func (flavor *Flavor) createServiceAccount(nfsNamespace string) error {
 	return nil
 }
 
-func (flavor *Flavor) createNFSConfigMap(nfsNamespace string) error {
-	log.Tracef(">>>>> createNFSConfigMap with namespace %s", nfsNamespace)
+func (flavor *Flavor) createNFSConfigMap(nfsNamespace, hostDomain string) error {
+	log.Tracef(">>>>> createNFSConfigMap with namespace %s, domain %s", nfsNamespace, hostDomain)
 	defer log.Tracef("<<<<< createNFSConfigMap")
 
-	nfsGaneshaConfig := `
-NFS_Core_Param
-{
-  NFS_Protocols= 4;
-  NFS_Port = 2049;
-  fsid_device = false;
-}
-
-EXPORT
-{
-  Export_Id = 716;
-  Path = /export;
-  Pseudo = /export;
-  Access_Type = RW;
-  Squash = No_Root_Squash;
-  Transports = TCP;
-  Protocols = 4;
-  SecType = "sys";
-  FSAL {
-	  Name = VFS;
-  }
-}`
+	// Format for pretty display with configmap
+	nfsCoreParamBlock := "NFS_Core_Param" + "\n" + "{" + "\n" + "NFS_Protocols= 4;" + "\n" + "NFS_Port = 2049;" + "\n" + "fsid_device = false;" + "\n" + "}" + "\n"
+	nfs4Block := "NFSv4" + "\n" + "{" + "\n" + "Graceless = true;" + "\n" + "UseGetpwnam = true;" + "\n" + "DomainName = " + hostDomain + ";" + "\n" + "}" + "\n"
+	exportBlock := "EXPORT" + "\n" + "{" + "\n" + "Export_Id = 716;" + "\n" + "Path = /export;" + "\n" + "Pseudo = /export;" + "\n" + "Access_Type = RW;" + "\n" + "Squash = No_Root_Squash;" + "\n" + "Transports = TCP;" + "\n" + "Protocols = 4;" + "\n" + "SecType = \"sys\";" + "\n" + "FSAL" + "\n" + "{" + "\n" + "Name = VFS;" + "\n" + "}" + "\n" + "}" + "\n"
+	nfsGaneshaConfig := nfsCoreParamBlock + nfs4Block + exportBlock
 
 	configMap := &core_v1.ConfigMap{
 		ObjectMeta: meta_v1.ObjectMeta{
@@ -338,7 +328,6 @@ func (flavor *Flavor) HandleNFSNodePublish(chapiDriver chapi.Driver, req *csi.No
 	}
 	clusterIP := service.Spec.ClusterIP
 
-	// TODO: add nfs mount support in chapi
 	source := fmt.Sprintf("%s:%s", clusterIP, defaultExportPath)
 	target := req.GetTargetPath()
 	log.Debugf("mounting nfs volume %s to %s", source, target)
@@ -347,6 +336,7 @@ func (flavor *Flavor) HandleNFSNodePublish(chapiDriver chapi.Driver, req *csi.No
 		// use default mount options, i.e (rw,relatime,vers=4.0,rsize=1048576,wsize=1048576,namlen=255,hard,proto=tcp,timeo=600,retrans=2,sec=sys,local_lock=none)
 		mountOptions = []string{
 			"nolock",
+			"vers=4",
 		}
 	}
 	mountOptions = append(mountOptions, fmt.Sprintf("addr=%s", clusterIP))
@@ -859,33 +849,19 @@ func (flavor *Flavor) deleteNFSService(svcName string, nfsNamespace string) erro
 	log.Tracef(">>>>> deleteNFSService with service %s", svcName)
 	defer log.Tracef("<<<<< deleteNFSService")
 
-	// check if service  exists
-	getAction := func() error {
-		_, err := flavor.kubeClient.CoreV1().Services(nfsNamespace).Get(svcName, meta_v1.GetOptions{})
-		return err
-	}
-	exists, err := flavor.resourceExists(getAction, "service", svcName)
-	if err != nil {
-		return fmt.Errorf("failed to detect if there is a NFS service to delete. %+v", err)
-	}
-	if !exists {
-		log.Infof("nfs service %s does not exist in %s namespace", svcName, nfsNamespace)
-		return nil
-	}
-
 	log.Infof("Deleting nfs service %s from %s namespace", svcName, nfsNamespace)
 
-	var gracePeriod int64
-	propagation := meta_v1.DeletePropagationForeground
-	options := &meta_v1.DeleteOptions{GracePeriodSeconds: &gracePeriod, PropagationPolicy: &propagation}
+	propagation := meta_v1.DeletePropagationBackground
+	options := &meta_v1.DeleteOptions{PropagationPolicy: &propagation}
 
 	// Delete the nfs service
-	err = flavor.kubeClient.CoreV1().Services(nfsNamespace).Delete(svcName, options)
+	err := flavor.kubeClient.CoreV1().Services(nfsNamespace).Delete(svcName, options)
 	if err != nil && !errors.IsNotFound(err) {
 		log.Errorf("failed to delete nfs service %s, err %+v", svcName, err)
+		return err
 	}
 
-	log.Infof("Completed deletion of nfs service %s", svcName)
+	log.Infof("Triggered deletion of nfs service %s", svcName)
 	return nil
 }
 
@@ -894,18 +870,16 @@ func (flavor *Flavor) deleteNFSDeployment(name string, nfsNamespace string) erro
 	log.Tracef(">>>>> deleteNFSDeployment with %s", name)
 	defer log.Tracef("<<<<< deleteNFSDeployment")
 
-	deleteAction := func(options *meta_v1.DeleteOptions) error {
-		return flavor.kubeClient.AppsV1().Deployments(nfsNamespace).Delete(name, options)
-	}
-	getAction := func() error {
-		_, err := flavor.kubeClient.AppsV1().Deployments(nfsNamespace).Get(name, meta_v1.GetOptions{})
+	propagation := meta_v1.DeletePropagationBackground
+	options := &meta_v1.DeleteOptions{PropagationPolicy: &propagation}
+
+	err := flavor.kubeClient.AppsV1().Deployments(nfsNamespace).Delete(name, options)
+	if err != nil && !errors.IsNotFound(err) {
+		log.Errorf("failed to delete nfs deployment %s, err %+v", name, err)
 		return err
 	}
-	err := flavor.deleteResourceAndWait(nfsNamespace, name, "deployment", deleteAction, getAction)
-	if err != nil {
-		return err
-	}
-	log.Infof("Completed deletion of nfs deployment %s", name)
+
+	log.Infof("Triggered deletion of nfs deployment %s", name)
 	return nil
 }
 
@@ -914,19 +888,15 @@ func (flavor *Flavor) deleteNFSPVC(claimName string, nfsNamespace string) error 
 	log.Tracef(">>>>> deleteNFSPVC with %s", claimName)
 	defer log.Tracef("<<<<< deleteNFSPVC")
 
+	propagation := meta_v1.DeletePropagationBackground
+	options := &meta_v1.DeleteOptions{PropagationPolicy: &propagation}
 	// Delete the pvc
-	deleteAction := func(options *meta_v1.DeleteOptions) error {
-		return flavor.kubeClient.CoreV1().PersistentVolumeClaims(nfsNamespace).Delete(claimName, options)
-	}
-	getAction := func() error {
-		_, err := flavor.kubeClient.CoreV1().PersistentVolumeClaims(nfsNamespace).Get(claimName, meta_v1.GetOptions{})
+	err := flavor.kubeClient.CoreV1().PersistentVolumeClaims(nfsNamespace).Delete(claimName, options)
+	if err != nil && !errors.IsNotFound(err) {
+		log.Errorf("failed to delete nfs pvc %s, err %+v", claimName, err)
 		return err
 	}
-	err := flavor.deleteResourceAndWait(nfsNamespace, claimName, "persistentvolumeclaim", deleteAction, getAction)
-	if err != nil {
-		return err
-	}
-	log.Infof("Completed deletion of PVC %s", claimName)
+	log.Infof("Triggered deletion of PVC %s", claimName)
 	return nil
 }
 
@@ -943,83 +913,6 @@ func (flavor *Flavor) resourceExists(getAction func() error, resourceType string
 		return false, fmt.Errorf("failed to get %s %s, err %+v", resourceType, resourceName, err)
 	}
 	return true, nil
-}
-
-func (flavor *Flavor) deploymentExists(deploymentName string, nfsNamespace string) (bool, error) {
-	log.Tracef(">>>>> deploymentExists with %s", deploymentName)
-	defer log.Tracef("<<<<< deploymentExists")
-
-	_, err := flavor.kubeClient.AppsV1().Deployments(nfsNamespace).Get(deploymentName, meta_v1.GetOptions{})
-	if err == nil {
-		// the deployment was found
-		return true, nil
-	}
-	if !errors.IsNotFound(err) {
-		return false, err
-	}
-
-	// deployment not found
-	return false, nil
-}
-
-// Check if the NFS service exists
-func (flavor *Flavor) serviceExists(svcName string, nfsNamespace string) (bool, error) {
-	log.Tracef(">>>>> serviceExists with %s", svcName)
-	defer log.Tracef("<<<<< serviceExists")
-
-	_, err := flavor.kubeClient.CoreV1().Services(nfsNamespace).Get(svcName, meta_v1.GetOptions{})
-	if err == nil {
-		// the deployment was found
-		return true, nil
-	}
-	if !errors.IsNotFound(err) {
-		return false, err
-	}
-
-	// service not found
-	return false, err
-}
-
-// deleteResourceAndWait will delete a resource, then wait for it to be purged from the system
-func (flavor *Flavor) deleteResourceAndWait(namespace, name, resourceType string,
-	deleteAction func(*meta_v1.DeleteOptions) error,
-	getAction func() error,
-) error {
-	log.Tracef(">>>>> deleteResourceAndWait with %s %s", resourceType, name)
-	defer log.Tracef("<<<<< deleteResourceAndWait")
-
-	var gracePeriod int64
-	propagation := meta_v1.DeletePropagationForeground
-	options := &meta_v1.DeleteOptions{GracePeriodSeconds: &gracePeriod, PropagationPolicy: &propagation}
-
-	// Delete the resource if it exists
-	log.Infof("removing %s %s if it exists", resourceType, name)
-	err := deleteAction(options)
-	if err != nil {
-		if !errors.IsNotFound(err) {
-			return fmt.Errorf("failed to delete %s %s, err %+v", resourceType, name, err)
-		}
-		return nil
-	}
-	log.Infof("Removed %s %s", resourceType, name)
-
-	// wait for the resource to be deleted
-	sleepTime := deletionDelay
-	for i := 0; i < deletionInterval; i++ {
-		// check for the existence of the resource
-		err = getAction()
-		if err != nil {
-			if errors.IsNotFound(err) {
-				log.Infof("confirmed %s %s does not exist", resourceType, name)
-				return nil
-			}
-			return fmt.Errorf("failed to get %s %s. %+v", resourceType, name, err)
-		}
-
-		log.Infof("%s %s still found. waiting(try %d)...", resourceType, name, i+1)
-		time.Sleep(sleepTime)
-	}
-	return fmt.Errorf("gave up waiting for %s %s to be terminated", resourceType, name)
 }
 
 func (flavor *Flavor) waitForPVCCreation(claimName, nfsNamespace string) error {

--- a/pkg/flavor/kubernetes/nfs_test.go
+++ b/pkg/flavor/kubernetes/nfs_test.go
@@ -96,7 +96,7 @@ func TestCreateServiceAccount(t *testing.T) {
 }
 
 func TestCreateConfigMap(t *testing.T) {
-	err := flavor.createNFSConfigMap(defaultNFSNamespace)
+	err := flavor.createNFSConfigMap(defaultNFSNamespace, "testdomain.com")
 	assert.Nil(t, err)
 	configMap, err := flavor.kubeClient.CoreV1().ConfigMaps(defaultNFSNamespace).Get(nfsConfigMap, metav1.GetOptions{})
 	assert.Nil(t, err)

--- a/pkg/flavor/types.go
+++ b/pkg/flavor/types.go
@@ -27,7 +27,7 @@ type Flavor interface {
 	GetEphemeralVolumeSecretFromPod(volumeHandle string, podName string, namespace string) (string, error)
 	GetCredentialsFromSecret(name string, namespace string) (map[string]string, error)
 	IsPodExists(uid string) (bool, error)
-	CreateNFSVolume(pvName string, reqVolSize int64, parameters map[string]string, volumeContentSource *csi.VolumeContentSource) (nfsVolume *csi.Volume, rollback bool, err error)
+	CreateNFSVolume(chapiDriver chapi.Driver, pvName string, reqVolSize int64, parameters map[string]string, volumeContentSource *csi.VolumeContentSource) (nfsVolume *csi.Volume, rollback bool, err error)
 	DeleteNFSVolume(pvName string) error
 	RollbackNFSResources(nfsResourceName, nfsNamespace string) error
 	HandleNFSNodePublish(chapiDriver chapi.Driver, request *csi.NodePublishVolumeRequest) (*csi.NodePublishVolumeResponse, error)

--- a/pkg/flavor/types.go
+++ b/pkg/flavor/types.go
@@ -4,7 +4,6 @@ package flavor
 
 import (
 	"github.com/container-storage-interface/spec/lib/go/csi"
-	"github.com/hpe-storage/common-host-libs/chapi"
 	"github.com/hpe-storage/common-host-libs/model"
 	"k8s.io/apimachinery/pkg/version"
 )
@@ -27,10 +26,10 @@ type Flavor interface {
 	GetEphemeralVolumeSecretFromPod(volumeHandle string, podName string, namespace string) (string, error)
 	GetCredentialsFromSecret(name string, namespace string) (map[string]string, error)
 	IsPodExists(uid string) (bool, error)
-	CreateNFSVolume(chapiDriver chapi.Driver, pvName string, reqVolSize int64, parameters map[string]string, volumeContentSource *csi.VolumeContentSource) (nfsVolume *csi.Volume, rollback bool, err error)
+	CreateNFSVolume(pvName string, reqVolSize int64, parameters map[string]string, volumeContentSource *csi.VolumeContentSource) (nfsVolume *csi.Volume, rollback bool, err error)
 	DeleteNFSVolume(pvName string) error
 	RollbackNFSResources(nfsResourceName, nfsNamespace string) error
-	HandleNFSNodePublish(chapiDriver chapi.Driver, request *csi.NodePublishVolumeRequest) (*csi.NodePublishVolumeResponse, error)
+	HandleNFSNodePublish(request *csi.NodePublishVolumeRequest) (*csi.NodePublishVolumeResponse, error)
 	IsNFSVolume(volumeID string) bool
 	GetVolumePropertyOfPV(propertyName string, pvName string) (string, error)
 	GetNFSVolumeID(volumeID string) (string, error)

--- a/pkg/flavor/vanilla/flavor.go
+++ b/pkg/flavor/vanilla/flavor.go
@@ -60,7 +60,7 @@ func (flavor *Flavor) IsPodExists(uid string) (bool, error) {
 	return false, nil
 }
 
-func (flavor *Flavor) CreateNFSVolume(pvName string, reqVolSize int64, parameters map[string]string, volumeContentSource *csi.VolumeContentSource) (nfsVolume *csi.Volume, rollback bool, err error) {
+func (flavor *Flavor) CreateNFSVolume(chapiDriver chapi.Driver, pvName string, reqVolSize int64, parameters map[string]string, volumeContentSource *csi.VolumeContentSource) (nfsVolume *csi.Volume, rollback bool, err error) {
 	return nil, false, fmt.Errorf("NFS provisioned volume is not supported for non-k8s environments")
 }
 

--- a/pkg/flavor/vanilla/flavor.go
+++ b/pkg/flavor/vanilla/flavor.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
-	"github.com/hpe-storage/common-host-libs/chapi"
 	"github.com/hpe-storage/common-host-libs/model"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -60,7 +59,7 @@ func (flavor *Flavor) IsPodExists(uid string) (bool, error) {
 	return false, nil
 }
 
-func (flavor *Flavor) CreateNFSVolume(chapiDriver chapi.Driver, pvName string, reqVolSize int64, parameters map[string]string, volumeContentSource *csi.VolumeContentSource) (nfsVolume *csi.Volume, rollback bool, err error) {
+func (flavor *Flavor) CreateNFSVolume(pvName string, reqVolSize int64, parameters map[string]string, volumeContentSource *csi.VolumeContentSource) (nfsVolume *csi.Volume, rollback bool, err error) {
 	return nil, false, fmt.Errorf("NFS provisioned volume is not supported for non-k8s environments")
 }
 
@@ -72,7 +71,7 @@ func (flavor *Flavor) DeleteNFSVolume(pvName string) error {
 	return fmt.Errorf("NFS provisioned volume is not supported for non-k8s environments")
 }
 
-func (flavor *Flavor) HandleNFSNodePublish(chapiDriver chapi.Driver, request *csi.NodePublishVolumeRequest) (*csi.NodePublishVolumeResponse, error) {
+func (flavor *Flavor) HandleNFSNodePublish(request *csi.NodePublishVolumeRequest) (*csi.NodePublishVolumeResponse, error) {
 	return nil, status.Error(codes.Internal, "NFS provisioned volume is not supported for non-k8s environments")
 }
 

--- a/vendor/github.com/hpe-storage/common-host-libs/logger/logger.go
+++ b/vendor/github.com/hpe-storage/common-host-libs/logger/logger.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Hewlett Packard Enterprise Development LP
+// Copyright 2020 Hewlett Packard Enterprise Development LP
 
 package logger
 
@@ -330,6 +330,17 @@ func (hook *FileHook) Fire(entry *log.Entry) error {
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Could not read log entry. %v", err)
 		return err
+	}
+
+	// For Windows only, insert '/r' in front of any tailing '/n'.  Windows text files end
+	// lines with CRLF while other platforms just end with LF.
+	if runtime.GOOS == "windows" {
+		for i := len(lineBytes) - 1; i > 0; i-- {
+			if (lineBytes[i] != '\n') || (i > 0 && lineBytes[i-1] == '\r') {
+				break
+			}
+			lineBytes = append(lineBytes[:i], append([]byte{'\r'}, lineBytes[i:]...)...)
+		}
 	}
 
 	hook.logWriter.Write(lineBytes)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -72,7 +72,7 @@ github.com/hpcloud/tail/ratelimiter
 github.com/hpcloud/tail/util
 github.com/hpcloud/tail/watch
 github.com/hpcloud/tail/winfile
-# github.com/hpe-storage/common-host-libs v0.0.0-20200516064614-43272f9d4d33
+# github.com/hpe-storage/common-host-libs v0.0.0-20200520064700-5130e102775b
 github.com/hpe-storage/common-host-libs/chapi
 github.com/hpe-storage/common-host-libs/concurrent
 github.com/hpe-storage/common-host-libs/connectivity


### PR DESCRIPTION
* Problem:
  * 1. Domain name used by nfs-server by default(localdomain) causes conflict
  * when NFS clients require host domain name for mounts. This causes nobody:nobody files.
  * 2. Default NFS version is 3 in some Ubuntu distros, causing RPC procedure
  * not available errors
  * 3. Foreground deletion is used to cleanup resources, which causes timeout
  * of RWX PV deletion, but when retry is attempted, since underlying RWO PV
  * is deleted by then, we can't figureout RWX PV to be of NFS type, causing stale PV's.
  * 4. Default GracePeriod for NFS server to be idle after startup is 90s. This causes
  * initial I/O to be hung soon after app pods are started.
  * 5. ConfigMap is not displayed in pretty format during edit
* Implementation:
  * 1. Domain name is added to ganesha.conf using dnsdomainname, allowing NFS clients
  * to mount correctly where idmap is disabled.
  * 2. Default vers=4 is set during mount as NFS server is always started with 4.0 version as default.
  * It can be overridden by user using configmap and SC param nfsMountOptions
  * 3. Changed cleanup logic to background, so timeouts wont happen with RWX PV.
  * In the background, these deletions can take time and k8s takes care of that.
  * 4. Start NFS server with GraceLess option. Seems like general practice in container mode.
  * 5. Format configmap with individual strings rather than using back ticks. This allows user to easily edit it later.
* Testing: tested with deployments on Ubuntu/RHEL/CoreOS.
* Review: gcostea, rkumar
Signed-off-by: Shiva Krishna, Merla <shivakrishna.merla@hpe.com>