### PR TITLE
nfs: increase wait time for deployment to 5min

### DIFF
--- a/pkg/flavor/kubernetes/nfs.go
+++ b/pkg/flavor/kubernetes/nfs.go
@@ -26,8 +26,8 @@ const (
 	defaultNFSNamespace = "hpe-nfs"
 	defaultNFSImage     = "hpestorage/nfs-provisioner:2.8.3-4"
 
-	creationInterval           = 150 // 300s with sleep interval of 2s
-	creationDelay              = 2 * time.Second
+	creationInterval           = 60 // 300s with sleep interval of 5s
+	creationDelay              = 5 * time.Second
 	defaultExportPath          = "/export"
 	nfsResourceLimitsCPUKey    = "nfsResourceLimitsCpuM"
 	nfsResourceLimitsMemoryKey = "nfsResourceLimitsMemoryMi"
@@ -965,7 +965,7 @@ func (flavor *Flavor) waitForPVCCreation(claimName, nfsNamespace string) error {
 			time.Sleep(sleepTime)
 			continue
 		} else if !claim.ObjectMeta.DeletionTimestamp.IsZero() {
-			log.Errorf("existing pvc %s is under deletion, return error to retry later...", claimName)
+			log.Warnf("rollback of an existing pvc %s is under progress, returning error", claimName)
 			return fmt.Errorf("rollback of an existing pvc %s is under progress", claimName)
 		}
 		// successfully bound

--- a/pkg/flavor/kubernetes/nfs.go
+++ b/pkg/flavor/kubernetes/nfs.go
@@ -26,7 +26,7 @@ const (
 	defaultNFSNamespace = "hpe-nfs"
 	defaultNFSImage     = "hpestorage/nfs-provisioner:2.8.3-4"
 
-	creationInterval           = 60 // 120s with sleep interval of 2s
+	creationInterval           = 150 // 300s with sleep interval of 2s
 	creationDelay              = 2 * time.Second
 	defaultExportPath          = "/export"
 	nfsResourceLimitsCPUKey    = "nfsResourceLimitsCpuM"
@@ -681,7 +681,6 @@ func (flavor *Flavor) createNFSDeployment(deploymentName string, nfsSpec *NFSSpe
 			return fmt.Errorf("failed to create nfs deployment %s, err %+v", deploymentName, err)
 		}
 		log.Infof("nfs deployment %s already exists", deploymentName)
-		return nil
 	}
 	// make sure its available
 	err := flavor.waitForDeployment(deploymentName, nfsNamespace)
@@ -965,6 +964,9 @@ func (flavor *Flavor) waitForPVCCreation(claimName, nfsNamespace string) error {
 			log.Infof("pvc %s still not bound to pv, current state %s. waiting(try %d)...", claimName, claim.Status.Phase, i+1)
 			time.Sleep(sleepTime)
 			continue
+		} else if !claim.ObjectMeta.DeletionTimestamp.IsZero() {
+			log.Errorf("existing pvc %s is under deletion, return error to retry later...", claimName)
+			return fmt.Errorf("rollback of an existing pvc %s is under progress", claimName)
 		}
 		// successfully bound
 		return nil
@@ -985,7 +987,7 @@ func (flavor *Flavor) waitForDeployment(deploymentName string, nfsNamespace stri
 			return fmt.Errorf("failed to get deployment %s, err %+v", deploymentName, err)
 		}
 		if deployment.Status.AvailableReplicas != 1 {
-			log.Infof("pvc %s still not bound to pv. waiting(try %d)...", deploymentName, i+1)
+			log.Infof("deployment %s is still not available. waiting(try %d)...", deploymentName, i+1)
 			time.Sleep(sleepTime)
 			continue
 		}


### PR DESCRIPTION
* Problem:
  * If app pods and NFS pods are started simultaneously, then
  * NFS mounts are slow initially and can take more than 2 mins to start.
  * Current wait time of 2min, will cause un-necessary rollbacks and retries.
* Implementation:
  * Change minimum wait interval to 5min to avoid un-necessary rollback and retries
  * waiting for NFS deployment to be ready.
* Testing: tested with 20 NFS pods and 80 application pods.
* Review: rkumar
Signed-off-by: Shiva Krishna, Merla <shivakrishna.merla@hpe.com>