### PR TITLE
nfs: Assume NFS resources for RWX/ROX volumes

### DIFF
--- a/pkg/driver/controller_server.go
+++ b/pkg/driver/controller_server.go
@@ -300,6 +300,11 @@ func (driver *Driver) createVolume(
 			filesystem = defaultFileSystem
 			log.Trace("Using default filesystem type: ", filesystem)
 		}
+		// Assume nfsResources for multi-access mode and mount type
+		// NOTE: When we support backend with NFS, this check has to be handled accordingly.
+		if driver.IsSupportedMultiNodeAccessMode(volumeCapabilities) {
+			createParameters[nfsResourcesKey] = trueKey
+		}
 	}
 
 	// Verify if NFS based provisioning is requested

--- a/pkg/driver/controller_server.go
+++ b/pkg/driver/controller_server.go
@@ -300,10 +300,8 @@ func (driver *Driver) createVolume(
 			filesystem = defaultFileSystem
 			log.Trace("Using default filesystem type: ", filesystem)
 		}
-		// Assume nfsResources for multi-access mode and mount type
-		// NOTE: When we support backend with NFS, this check has to be handled accordingly.
-		if driver.IsSupportedMultiNodeAccessMode(volumeCapabilities) {
-			createParameters[nfsResourcesKey] = trueKey
+		if driver.IsSupportedMultiNodeAccessMode(volumeCapabilities) && !driver.IsNFSResourceRequest(createParameters) {
+			return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("StorageClass parameter %s=%s is missing for creation of volumes with multi-node access", nfsResourcesKey, trueKey))
 		}
 	}
 

--- a/pkg/flavor/kubernetes/nfs.go
+++ b/pkg/flavor/kubernetes/nfs.go
@@ -904,7 +904,8 @@ func (flavor *Flavor) deleteNFSDeployment(name string, nfsNamespace string) erro
 	defer log.Tracef("<<<<< deleteNFSDeployment")
 
 	propagation := meta_v1.DeletePropagationBackground
-	options := &meta_v1.DeleteOptions{PropagationPolicy: &propagation}
+	gracePeriod := int64(5)
+	options := &meta_v1.DeleteOptions{PropagationPolicy: &propagation, GracePeriodSeconds: &gracePeriod}
 
 	err := flavor.kubeClient.AppsV1().Deployments(nfsNamespace).Delete(name, options)
 	if err != nil && !errors.IsNotFound(err) {


### PR DESCRIPTION
* Problem:
  * Currently when RWX/ROX volumes are created without nfsResources flag
  * we allow block volume creation, without any NFS resources.
  * As this volume can be attached to multiple nodes/apps, without distributed
  * filesystem, this will cause data inconsistencies.
* Implementation:
  * Assume nfsResources are requested with RWX/ROX access types. When backend
  * itself supports NFS, then we need to get serverIP etc from sc params and
  * when that support is added, we can change this assumption along with other changes
  * to bypass node stage etc.
* Testing: creation of RWX/ROX volumes without any additional NFS flags.
* Review: gcostea, rkumar
Signed-off-by: Shiva Krishna, Merla <shivakrishna.merla@hpe.com>