### PR TITLE
nfs: use v1.0.0 as starting tag for nfs-provisioner

### DIFF
--- a/pkg/flavor/kubernetes/nfs.go
+++ b/pkg/flavor/kubernetes/nfs.go
@@ -838,7 +838,7 @@ func (flavor *Flavor) makeContainer(name string, nfsSpec *NFSSpec) core_v1.Conta
 		Env: []core_v1.EnvVar{
 			{
 				Name:  "GANESHA_OPTIONS",
-				Value: getEnv("GANESHA_OPTIONS", "-N NIV_EVENT"),
+				Value: getEnv("GANESHA_OPTIONS", "-N NIV_WARN"),
 			},
 		},
 		Ports: []core_v1.ContainerPort{

--- a/pkg/flavor/kubernetes/nfs.go
+++ b/pkg/flavor/kubernetes/nfs.go
@@ -24,7 +24,7 @@ import (
 const (
 	nfsPrefix           = "hpe-nfs-"
 	defaultNFSNamespace = "hpe-nfs"
-	defaultNFSImage     = "hpestorage/nfs-provisioner:2.8.3-4"
+	defaultNFSImage     = "hpestorage/nfs-provisioner:v1.0.0"
 
 	creationInterval           = 60 // 300s with sleep interval of 5s
 	creationDelay              = 5 * time.Second
@@ -833,7 +833,7 @@ func (flavor *Flavor) makeContainer(name string, nfsSpec *NFSSpec) core_v1.Conta
 	cont := core_v1.Container{
 		Name:            name,
 		Image:           nfsSpec.image,
-		ImagePullPolicy: core_v1.PullAlways,
+		ImagePullPolicy: core_v1.PullIfNotPresent,
 		SecurityContext: securityContext,
 		Env: []core_v1.EnvVar{
 			{


### PR DESCRIPTION
* Problem:
  * nfs-ganesha version was used as tag
  * ImagePullPolicy of Always increases time for container startup.
* Implementation:
  * as its implemention detail, re-tag from v1.0.0
  * Change image pull policy as IfNotPresent
* Testing: deployed nfs pods
* Review:
Signed-off-by: Shiva Krishna, Merla <shivakrishna.merla@hpe.com>