### PR TITLE
Accomodate scanning for multiple lun id

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway v1.12.0 // indirect
 	github.com/hashicorp/golang-lru v0.5.3 // indirect
-	github.com/hpe-storage/common-host-libs v4.2.1-0.20200706204556-55cdf4356dfa+incompatible
+	github.com/hpe-storage/common-host-libs v4.2.1-0.20200724035537-cf0f6aa92d3d+incompatible
 	github.com/hpe-storage/k8s-custom-resources v0.0.0-20190828052325-42886f48215c
 	github.com/jonboulle/clockwork v0.1.0 // indirect
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -176,6 +176,8 @@ github.com/hpe-storage/common-host-libs v0.0.0-20200601164253-a5ef69310997/go.mo
 github.com/hpe-storage/common-host-libs v4.1.0+incompatible h1:NCjBLmpM5P6sXqjvN/Fy5+Lz2HV2HA4F6G81PwjLd9E=
 github.com/hpe-storage/common-host-libs v4.2.1-0.20200706204556-55cdf4356dfa+incompatible h1:Y90h773hTIQkB9Bf1sPrwxfU9lfu2e2NBoWxHb6b3vI=
 github.com/hpe-storage/common-host-libs v4.2.1-0.20200706204556-55cdf4356dfa+incompatible/go.mod h1:qQxvwt4l9C79p2V8bY1P13As1+ylyznKJVp3K2P5bz8=
+github.com/hpe-storage/common-host-libs v4.2.1-0.20200724035537-cf0f6aa92d3d+incompatible h1:fU1x1ogqsQMyEaD5ImrWP7jTt9xClB1kls47h3wMls4=
+github.com/hpe-storage/common-host-libs v4.2.1-0.20200724035537-cf0f6aa92d3d+incompatible/go.mod h1:qQxvwt4l9C79p2V8bY1P13As1+ylyznKJVp3K2P5bz8=
 github.com/hpe-storage/k8s-custom-resources v0.0.0-20190828052325-42886f48215c h1:M/4pHhSouEEjd613SFODOskZmn6pS5tWITHdA8MPWMI=
 github.com/hpe-storage/k8s-custom-resources v0.0.0-20190828052325-42886f48215c/go.mod h1:qYST/Hepa2MRB85zskShx/+WlbUG5bmq/orhy6sA2jE=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=

--- a/pkg/driver/constants.go
+++ b/pkg/driver/constants.go
@@ -41,7 +41,7 @@ const (
 	targetScopeKey    = "targetScope"
 	lunIDKey          = "lunId"
 
-	secondaryArrayDetailsKey = "secondArrayDetailsKey"
+	secondaryArrayDetailsKey = "secondaryArrayDetailsKey"
 
 	discoveryIPsKey       = "discoveryIps"
 	chapUsernameKey       = "chapUsername"

--- a/pkg/driver/constants.go
+++ b/pkg/driver/constants.go
@@ -43,10 +43,6 @@ const (
 
 	secondaryArrayDetailsKey = "secondArrayDetailsKey"
 
-	secondaryLunIDKey       = "secondaryLunIdKey"
-	secondaryTargetNamesKey = "secondaryTargetNamesKey"
-	secondaryDiscoveryIpKey = "secondaryDiscoveryIpKey"
-
 	discoveryIPsKey       = "discoveryIps"
 	chapUsernameKey       = "chapUsername"
 	chapPasswordKey       = "chapPassword"

--- a/pkg/driver/constants.go
+++ b/pkg/driver/constants.go
@@ -41,6 +41,8 @@ const (
 	targetScopeKey    = "targetScope"
 	lunIDKey          = "lunId"
 
+	secondaryArrayDetailsKey = "secondArrayDetailsKey"
+
 	secondaryLunIDKey       = "secondaryLunIdKey"
 	secondaryTargetNamesKey = "secondaryTargetNamesKey"
 	secondaryDiscoveryIpKey = "secondaryDiscoveryIpKey"

--- a/pkg/driver/constants.go
+++ b/pkg/driver/constants.go
@@ -40,6 +40,7 @@ const (
 	targetNamesKey        = "targetNames"
 	targetScopeKey        = "targetScope"
 	lunIDKey              = "lunId"
+	peerLunIDs            = "peer_lun_ids"
 	discoveryIPsKey       = "discoveryIps"
 	chapUsernameKey       = "chapUsername"
 	chapPasswordKey       = "chapPassword"

--- a/pkg/driver/constants.go
+++ b/pkg/driver/constants.go
@@ -35,12 +35,16 @@ const (
 	targetScopeGroup = "group"
 
 	// Volume Publish params
-	serialNumberKey       = "serialNumber"
-	accessProtocolKey     = "accessProtocol"
-	targetNamesKey        = "targetNames"
-	targetScopeKey        = "targetScope"
-	lunIDKey              = "lunId"
-	peerLunIDs            = "peer_lun_ids"
+	serialNumberKey   = "serialNumber"
+	accessProtocolKey = "accessProtocol"
+	targetNamesKey    = "targetNames"
+	targetScopeKey    = "targetScope"
+	lunIDKey          = "lunId"
+
+	secondaryLunIDKey       = "secondaryLunIdKey"
+	secondaryTargetNamesKey = "secondaryTargetNamesKey"
+	secondaryDiscoveryIpKey = "secondaryDiscoveryIpKey"
+
 	discoveryIPsKey       = "discoveryIps"
 	chapUsernameKey       = "chapUsername"
 	chapPasswordKey       = "chapPassword"

--- a/pkg/driver/controller_server.go
+++ b/pkg/driver/controller_server.go
@@ -867,12 +867,12 @@ func (driver *Driver) controllerPublishVolume(
 	publishContext[lunIDKey] = strconv.Itoa(int(publishInfo.AccessInfo.BlockDeviceAccessInfo.LunID))
 
 	// Start of population of target array details
-	log.Tracef("\n PUBLISH INFO ::::: %v", publishInfo)
-
 	if publishInfo.AccessInfo.BlockDeviceAccessInfo.SecondaryBackendDetails.PeerArrayDetails != nil {
 		secondaryArrayMarshalledStr, err := json.Marshal(&publishInfo.AccessInfo.BlockDeviceAccessInfo.SecondaryBackendDetails)
 		if err != nil {
 			log.Errorf("Error in marshalling secondary details %s", err.Error())
+			return nil, status.Error(codes.Internal,
+				fmt.Sprintf("error in marshalling secondary array details %s", err.Error()))
 		} else {
 			log.Tracef("\n Marshalled secondary array str :%v", secondaryArrayMarshalledStr)
 			publishContext[secondaryArrayDetailsKey] = string(secondaryArrayMarshalledStr)

--- a/pkg/driver/controller_server.go
+++ b/pkg/driver/controller_server.go
@@ -5,6 +5,7 @@ package driver
 
 import (
 	b64 "encoding/base64"
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
@@ -869,32 +870,45 @@ func (driver *Driver) controllerPublishVolume(
 	log.Tracef("\n PUBLISH INFO ::::: %v", publishInfo)
 	numberOfSecondaryBackends := len(publishInfo.AccessInfo.BlockDeviceAccessInfo.SecondaryBackendDetails.PeerArrayDetails)
 	log.Tracef("\n NO OF BACKENDS: %d", numberOfSecondaryBackends)
-	var secondaryLunIds []int32 = make([]int32, numberOfSecondaryBackends)
-	var secondaryTargetNames []string
-	var secondaryDiscoveryIps []string
 
-	// Populate the list of secondary luns
-	for i := 0; i < numberOfSecondaryBackends; i++ {
-		// Populate the list of secondary target names
-		secondaryLunIds[i] = publishInfo.AccessInfo.BlockDeviceAccessInfo.SecondaryBackendDetails.PeerArrayDetails[i].LunID
-		for _, targetName := range publishInfo.AccessInfo.BlockDeviceAccessInfo.SecondaryBackendDetails.PeerArrayDetails[i].TargetNames {
-			secondaryTargetNames = append(secondaryTargetNames, targetName)
+	//var secondaryLunIds []int32 = make([]int32, numberOfSecondaryBackends)
+	//var secondaryTargetNames []string
+	//var secondaryDiscoveryIps []string
+
+	/*
+		// Populate the list of secondary luns
+		for i := 0; i < numberOfSecondaryBackends; i++ {
+			// Populate the list of secondary target names
+			secondaryLunIds[i] = publishInfo.AccessInfo.BlockDeviceAccessInfo.SecondaryBackendDetails.PeerArrayDetails[i].LunID
+			for _, targetName := range publishInfo.AccessInfo.BlockDeviceAccessInfo.SecondaryBackendDetails.PeerArrayDetails[i].TargetNames {
+				secondaryTargetNames = append(secondaryTargetNames, targetName)
+			}
+			// Populate the list of secondary discovery ips
+			for _, discoveryIp := range publishInfo.AccessInfo.BlockDeviceAccessInfo.SecondaryBackendDetails.PeerArrayDetails[i].DiscoveryIPs {
+				secondaryDiscoveryIps = append(secondaryDiscoveryIps, discoveryIp)
+			}
 		}
-		// Populate the list of secondary discovery ips
-		for _, discoveryIp := range publishInfo.AccessInfo.BlockDeviceAccessInfo.SecondaryBackendDetails.PeerArrayDetails[i].DiscoveryIPs {
-			secondaryDiscoveryIps = append(secondaryDiscoveryIps, discoveryIp)
+		publishContext[secondaryTargetNamesKey] = strings.Join(secondaryTargetNames, ",")
+		publishContext[secondaryLunIDKey] = util.ConvertArrayOfIntToString(secondaryLunIds)
+
+		// End of population of target array details
+	*/
+
+	if numberOfSecondaryBackends > 0 {
+		secondaryArrayMarshalledStr, err := json.Marshal(&publishInfo.AccessInfo.BlockDeviceAccessInfo.SecondaryBackendDetails)
+		if err != nil {
+			log.Errorf("Error in marshalling secondary details %s", err.Error())
+		} else {
+			log.Tracef("\n Marshalled secondary array str :%v", secondaryArrayMarshalledStr)
+			publishContext[secondaryArrayDetailsKey] = string(secondaryArrayMarshalledStr)
 		}
 	}
-	publishContext[secondaryTargetNamesKey] = strings.Join(secondaryTargetNames, ",")
-	publishContext[secondaryLunIDKey] = util.ConvertArrayOfIntToString(secondaryLunIds)
-
-	// End of population of target array details
 
 	if strings.EqualFold(publishInfo.AccessInfo.BlockDeviceAccessInfo.AccessProtocol, iscsi) {
 		publishContext[discoveryIPsKey] = strings.Join(publishInfo.AccessInfo.BlockDeviceAccessInfo.IscsiAccessInfo.DiscoveryIPs, ",")
 		publishContext[chapUsernameKey] = publishInfo.AccessInfo.BlockDeviceAccessInfo.IscsiAccessInfo.ChapUser
 		publishContext[chapPasswordKey] = publishInfo.AccessInfo.BlockDeviceAccessInfo.IscsiAccessInfo.ChapPassword
-		publishContext[secondaryDiscoveryIpKey] = strings.Join(secondaryDiscoveryIps, ",")
+		//publishContext[secondaryDiscoveryIpKey] = strings.Join(secondaryDiscoveryIps, ",")
 	}
 
 	if readOnlyAccessMode == true {

--- a/pkg/driver/controller_server.go
+++ b/pkg/driver/controller_server.go
@@ -863,7 +863,10 @@ func (driver *Driver) controllerPublishVolume(
 	publishContext[accessProtocolKey] = publishInfo.AccessInfo.BlockDeviceAccessInfo.AccessProtocol
 	publishContext[targetNamesKey] = strings.Join(publishInfo.AccessInfo.BlockDeviceAccessInfo.TargetNames, ",")
 	publishContext[targetScopeKey] = requestedTargetScope
-	publishContext[lunIDKey] = util.ConvertArrayOfIntToString(publishInfo.AccessInfo.BlockDeviceAccessInfo.LunID)
+	publishContext[lunIDKey] = strconv.Itoa(int(publishInfo.AccessInfo.BlockDeviceAccessInfo.LunID))
+	if len(publishInfo.AccessInfo.BlockDeviceAccessInfo.PeerLunIDs) > 0 {
+		publishContext[peerLunIDs] = util.ConvertArrayOfIntToString(publishInfo.AccessInfo.BlockDeviceAccessInfo.PeerLunIDs)
+	}
 	if strings.EqualFold(publishInfo.AccessInfo.BlockDeviceAccessInfo.AccessProtocol, iscsi) {
 		publishContext[discoveryIPsKey] = strings.Join(publishInfo.AccessInfo.BlockDeviceAccessInfo.IscsiAccessInfo.DiscoveryIPs, ",")
 		publishContext[chapUsernameKey] = publishInfo.AccessInfo.BlockDeviceAccessInfo.IscsiAccessInfo.ChapUser

--- a/pkg/driver/controller_server.go
+++ b/pkg/driver/controller_server.go
@@ -868,11 +868,8 @@ func (driver *Driver) controllerPublishVolume(
 
 	// Start of population of target array details
 	log.Tracef("\n PUBLISH INFO ::::: %v", publishInfo)
-	numberOfSecondaryBackends := len(publishInfo.AccessInfo.BlockDeviceAccessInfo.SecondaryBackendDetails.PeerArrayDetails)
-	log.Tracef("\n NO OF BACKENDS: %d", numberOfSecondaryBackends)
 
-
-	if numberOfSecondaryBackends > 0 {
+	if publishInfo.AccessInfo.BlockDeviceAccessInfo.SecondaryBackendDetails.PeerArrayDetails != nil {
 		secondaryArrayMarshalledStr, err := json.Marshal(&publishInfo.AccessInfo.BlockDeviceAccessInfo.SecondaryBackendDetails)
 		if err != nil {
 			log.Errorf("Error in marshalling secondary details %s", err.Error())

--- a/pkg/driver/controller_server.go
+++ b/pkg/driver/controller_server.go
@@ -863,7 +863,7 @@ func (driver *Driver) controllerPublishVolume(
 	publishContext[accessProtocolKey] = publishInfo.AccessInfo.BlockDeviceAccessInfo.AccessProtocol
 	publishContext[targetNamesKey] = strings.Join(publishInfo.AccessInfo.BlockDeviceAccessInfo.TargetNames, ",")
 	publishContext[targetScopeKey] = requestedTargetScope
-	publishContext[lunIDKey] = strconv.Itoa(int(publishInfo.AccessInfo.BlockDeviceAccessInfo.LunID))
+	publishContext[lunIDKey] = publishInfo.AccessInfo.BlockDeviceAccessInfo.LunID
 	if strings.EqualFold(publishInfo.AccessInfo.BlockDeviceAccessInfo.AccessProtocol, iscsi) {
 		publishContext[discoveryIPsKey] = strings.Join(publishInfo.AccessInfo.BlockDeviceAccessInfo.IscsiAccessInfo.DiscoveryIPs, ",")
 		publishContext[chapUsernameKey] = publishInfo.AccessInfo.BlockDeviceAccessInfo.IscsiAccessInfo.ChapUser

--- a/pkg/driver/controller_server.go
+++ b/pkg/driver/controller_server.go
@@ -871,28 +871,6 @@ func (driver *Driver) controllerPublishVolume(
 	numberOfSecondaryBackends := len(publishInfo.AccessInfo.BlockDeviceAccessInfo.SecondaryBackendDetails.PeerArrayDetails)
 	log.Tracef("\n NO OF BACKENDS: %d", numberOfSecondaryBackends)
 
-	//var secondaryLunIds []int32 = make([]int32, numberOfSecondaryBackends)
-	//var secondaryTargetNames []string
-	//var secondaryDiscoveryIps []string
-
-	/*
-		// Populate the list of secondary luns
-		for i := 0; i < numberOfSecondaryBackends; i++ {
-			// Populate the list of secondary target names
-			secondaryLunIds[i] = publishInfo.AccessInfo.BlockDeviceAccessInfo.SecondaryBackendDetails.PeerArrayDetails[i].LunID
-			for _, targetName := range publishInfo.AccessInfo.BlockDeviceAccessInfo.SecondaryBackendDetails.PeerArrayDetails[i].TargetNames {
-				secondaryTargetNames = append(secondaryTargetNames, targetName)
-			}
-			// Populate the list of secondary discovery ips
-			for _, discoveryIp := range publishInfo.AccessInfo.BlockDeviceAccessInfo.SecondaryBackendDetails.PeerArrayDetails[i].DiscoveryIPs {
-				secondaryDiscoveryIps = append(secondaryDiscoveryIps, discoveryIp)
-			}
-		}
-		publishContext[secondaryTargetNamesKey] = strings.Join(secondaryTargetNames, ",")
-		publishContext[secondaryLunIDKey] = util.ConvertArrayOfIntToString(secondaryLunIds)
-
-		// End of population of target array details
-	*/
 
 	if numberOfSecondaryBackends > 0 {
 		secondaryArrayMarshalledStr, err := json.Marshal(&publishInfo.AccessInfo.BlockDeviceAccessInfo.SecondaryBackendDetails)
@@ -908,7 +886,6 @@ func (driver *Driver) controllerPublishVolume(
 		publishContext[discoveryIPsKey] = strings.Join(publishInfo.AccessInfo.BlockDeviceAccessInfo.IscsiAccessInfo.DiscoveryIPs, ",")
 		publishContext[chapUsernameKey] = publishInfo.AccessInfo.BlockDeviceAccessInfo.IscsiAccessInfo.ChapUser
 		publishContext[chapPasswordKey] = publishInfo.AccessInfo.BlockDeviceAccessInfo.IscsiAccessInfo.ChapPassword
-		//publishContext[secondaryDiscoveryIpKey] = strings.Join(secondaryDiscoveryIps, ",")
 	}
 
 	if readOnlyAccessMode == true {

--- a/pkg/driver/controller_server.go
+++ b/pkg/driver/controller_server.go
@@ -863,7 +863,7 @@ func (driver *Driver) controllerPublishVolume(
 	publishContext[accessProtocolKey] = publishInfo.AccessInfo.BlockDeviceAccessInfo.AccessProtocol
 	publishContext[targetNamesKey] = strings.Join(publishInfo.AccessInfo.BlockDeviceAccessInfo.TargetNames, ",")
 	publishContext[targetScopeKey] = requestedTargetScope
-	publishContext[lunIDKey] = publishInfo.AccessInfo.BlockDeviceAccessInfo.LunID
+	publishContext[lunIDKey] = util.ConvertArrayOfIntToString(publishInfo.AccessInfo.BlockDeviceAccessInfo.LunID)
 	if strings.EqualFold(publishInfo.AccessInfo.BlockDeviceAccessInfo.AccessProtocol, iscsi) {
 		publishContext[discoveryIPsKey] = strings.Join(publishInfo.AccessInfo.BlockDeviceAccessInfo.IscsiAccessInfo.DiscoveryIPs, ",")
 		publishContext[chapUsernameKey] = publishInfo.AccessInfo.BlockDeviceAccessInfo.IscsiAccessInfo.ChapUser

--- a/pkg/driver/node_server.go
+++ b/pkg/driver/node_server.go
@@ -446,9 +446,6 @@ func (driver *Driver) setupDevice(publishContext map[string]string) (*model.Devi
 		LunID:          publishContext[lunIDKey],
 		DiscoveryIPs:   discoveryIps,
 		ConnectionMode: defaultConnectionMode,
-		/*SecondaryDiscoverIps: publishContext[secondaryDiscoveryIpKey],
-		SecondaryLunIDs:      publishContext[secondaryLunIDKey],
-		SecondaryTargetNames: publishContext[secondaryTargetNamesKey], */
 		SecondaryArrayDetails: publishContext[secondaryArrayDetailsKey],
 	}
 	if publishContext[accessProtocolKey] == iscsi {

--- a/pkg/driver/node_server.go
+++ b/pkg/driver/node_server.go
@@ -444,6 +444,7 @@ func (driver *Driver) setupDevice(publishContext map[string]string) (*model.Devi
 		Iqns:           iqns,
 		TargetScope:    publishContext[targetScopeKey],
 		LunID:          publishContext[lunIDKey],
+		PeerLunIDs:     publishContext[peerLunIDs],
 		DiscoveryIPs:   discoveryIps,
 		ConnectionMode: defaultConnectionMode,
 	}

--- a/pkg/driver/node_server.go
+++ b/pkg/driver/node_server.go
@@ -439,16 +439,17 @@ func (driver *Driver) setupDevice(publishContext map[string]string) (*model.Devi
 	iqns := strings.Split(publishContext[targetNamesKey], ",")
 
 	volume := &model.Volume{
-		SerialNumber:         publishContext[serialNumberKey],
-		AccessProtocol:       publishContext[accessProtocolKey],
-		Iqns:                 iqns,
-		TargetScope:          publishContext[targetScopeKey],
-		LunID:                publishContext[lunIDKey],
-		DiscoveryIPs:         discoveryIps,
-		ConnectionMode:       defaultConnectionMode,
-		SecondaryDiscoverIps: publishContext[secondaryDiscoveryIpKey],
+		SerialNumber:   publishContext[serialNumberKey],
+		AccessProtocol: publishContext[accessProtocolKey],
+		Iqns:           iqns,
+		TargetScope:    publishContext[targetScopeKey],
+		LunID:          publishContext[lunIDKey],
+		DiscoveryIPs:   discoveryIps,
+		ConnectionMode: defaultConnectionMode,
+		/*SecondaryDiscoverIps: publishContext[secondaryDiscoveryIpKey],
 		SecondaryLunIDs:      publishContext[secondaryLunIDKey],
-		SecondaryTargetNames: publishContext[secondaryTargetNamesKey],
+		SecondaryTargetNames: publishContext[secondaryTargetNamesKey], */
+		SecondaryArrayDetails: publishContext[secondaryArrayDetailsKey],
 	}
 	if publishContext[accessProtocolKey] == iscsi {
 		chapInfo := &model.ChapInfo{

--- a/pkg/driver/node_server.go
+++ b/pkg/driver/node_server.go
@@ -439,14 +439,16 @@ func (driver *Driver) setupDevice(publishContext map[string]string) (*model.Devi
 	iqns := strings.Split(publishContext[targetNamesKey], ",")
 
 	volume := &model.Volume{
-		SerialNumber:   publishContext[serialNumberKey],
-		AccessProtocol: publishContext[accessProtocolKey],
-		Iqns:           iqns,
-		TargetScope:    publishContext[targetScopeKey],
-		LunID:          publishContext[lunIDKey],
-		PeerLunIDs:     publishContext[peerLunIDs],
-		DiscoveryIPs:   discoveryIps,
-		ConnectionMode: defaultConnectionMode,
+		SerialNumber:         publishContext[serialNumberKey],
+		AccessProtocol:       publishContext[accessProtocolKey],
+		Iqns:                 iqns,
+		TargetScope:          publishContext[targetScopeKey],
+		LunID:                publishContext[lunIDKey],
+		DiscoveryIPs:         discoveryIps,
+		ConnectionMode:       defaultConnectionMode,
+		SecondaryDiscoverIps: publishContext[secondaryDiscoveryIpKey],
+		SecondaryLunIDs:      publishContext[secondaryLunIDKey],
+		SecondaryTargetNames: publishContext[secondaryTargetNamesKey],
 	}
 	if publishContext[accessProtocolKey] == iscsi {
 		chapInfo := &model.ChapInfo{

--- a/vendor/github.com/hpe-storage/common-host-libs/chapi/chapidriver_linux.go
+++ b/vendor/github.com/hpe-storage/common-host-libs/chapi/chapidriver_linux.go
@@ -218,8 +218,7 @@ func (driver *LinuxDriver) GetFilesystemFromDevice(device *model.Device) (*model
 func (driver *LinuxDriver) GetMounts(serialNumber string) ([]*model.Mount, error) {
 	log.Trace(">>>>> GetMounts, serialNumber: ", serialNumber)
 	defer log.Trace("<<<<< GetMounts")
-
-	devices, err := linux.GetLinuxDmDevices(false, serialNumber, "")
+	devices, err := linux.GetLinuxDmDevices(false, util.GetVolumeObject(serialNumber, ""))
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/hpe-storage/common-host-libs/chapi/handler_linux.go
+++ b/vendor/github.com/hpe-storage/common-host-libs/chapi/handler_linux.go
@@ -16,6 +16,7 @@ import (
 	log "github.com/hpe-storage/common-host-libs/logger"
 	"github.com/hpe-storage/common-host-libs/model"
 	"github.com/hpe-storage/common-host-libs/tunelinux"
+	"github.com/hpe-storage/common-host-libs/util"
 )
 
 var (
@@ -137,7 +138,8 @@ func getChapInfo(w http.ResponseWriter, r *http.Request) {
 //@Router /hosts/{id}/devices [get]
 func getDevices(w http.ResponseWriter, r *http.Request) {
 	function := func() (interface{}, error) {
-		return linux.GetLinuxDmDevices(false, "", "")
+
+		return linux.GetLinuxDmDevices(false, util.GetVolumeObject("", ""))
 	}
 	handleRequest(function, "getDevices", w, r)
 }
@@ -280,7 +282,7 @@ func getDeviceForSerialNumber(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	devices, err := linux.GetLinuxDmDevices(false, serialnumber, "")
+	devices, err := linux.GetLinuxDmDevices(false, util.GetVolumeObject(serialnumber, ""))
 	if err != nil {
 		handleError(w, chapiResp, err, http.StatusInternalServerError)
 		return
@@ -317,7 +319,7 @@ func getPartitionsForDevice(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	devices, err := linux.GetLinuxDmDevices(false, serialnumber, "")
+	devices, err := linux.GetLinuxDmDevices(false, util.GetVolumeObject(serialnumber, ""))
 	if err != nil {
 		handleError(w, chapiResp, err, http.StatusInternalServerError)
 		return
@@ -395,7 +397,7 @@ func getMountForDevice(w http.ResponseWriter, r *http.Request) {
 	mountid := vars["mountid"]
 	serialNumber := vars["serialNumber"]
 
-	devices, err := linux.GetLinuxDmDevices(false, serialNumber, "")
+	devices, err := linux.GetLinuxDmDevices(false, util.GetVolumeObject(serialNumber, ""))
 	if err != nil {
 		handleError(w, chapiResp, err, http.StatusInternalServerError)
 		return

--- a/vendor/github.com/hpe-storage/common-host-libs/linux/fc.go
+++ b/vendor/github.com/hpe-storage/common-host-libs/linux/fc.go
@@ -119,6 +119,7 @@ func RescanFcTarget(lunID string) (err error) {
 				log.Debugf("error writing to file %s : %s", fcHostScanPath, err.Error())
 			}
 		} else {
+			log.Tracef("\n SCANNING fc lun id %s", lunID)
 			err = ioutil.WriteFile(fcHostScanPath, []byte("- - "+lunID), 0644)
 			if err != nil {
 				log.Debugf("error writing to file %s : %s", fcHostScanPath, err.Error())

--- a/vendor/github.com/hpe-storage/common-host-libs/linux/iscsi.go
+++ b/vendor/github.com/hpe-storage/common-host-libs/linux/iscsi.go
@@ -4,10 +4,6 @@ package linux
 
 import (
 	"fmt"
-	log "github.com/hpe-storage/common-host-libs/logger"
-	"github.com/hpe-storage/common-host-libs/model"
-	"github.com/hpe-storage/common-host-libs/util"
-	ping "github.com/sparrc/go-ping"
 	"io/ioutil"
 	"net"
 	"os"
@@ -16,6 +12,11 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	log "github.com/hpe-storage/common-host-libs/logger"
+	"github.com/hpe-storage/common-host-libs/model"
+	"github.com/hpe-storage/common-host-libs/util"
+	ping "github.com/sparrc/go-ping"
 )
 
 const (
@@ -116,6 +117,39 @@ func getReachableDiscoveryPortals(discoveryIPs []string, virtualPortal bool) (re
 	return reachablePortals, nil
 }
 
+func updateChapForLoggedInTargets(volume *model.Volume) {
+	log.Tracef(">>>>> updateChapForLoggedInTargets for volume %s", volume.SerialNumber)
+	defer log.Tracef("<<<<< updateChapForLoggedInTargets")
+	loggedInTargets, _ := GetIscsiNodesFromIsciadm()
+	var chapUser, chapPassword string
+	if volume.Chap == nil {
+		chapUser = ""
+		chapPassword = ""
+	} else {
+		chapUser = volume.Chap.Name
+		chapPassword = volume.Chap.Password
+	}
+	for _, targetName := range volume.TargetNames() {
+		for _, loggedInTarget := range loggedInTargets {
+			// update only the targets matching the target iqn
+			if loggedInTarget.Name == targetName {
+				log.Tracef("updating chapUser for Targets :%s Portal :%s to %s", loggedInTarget.Name, loggedInTarget.Address, chapUser)
+				// update chapuser irrespective (could be a toggle case chap->empty)
+				err := updateChapUser(loggedInTarget, chapUser)
+				if err != nil {
+					// log and proceed for other targets
+					log.Errorf(err.Error())
+				}
+				err = updateChapPassword(loggedInTarget, chapPassword)
+				if err != nil {
+					// log and proceed for other targets
+					log.Errorf(err.Error())
+				}
+			}
+		}
+	}
+}
+
 // areTargetsLoggedIn returns true if all specified targets are logged-in
 func areTargetsLoggedIn(requiredTargets []string) (bool, error) {
 	loggedInTargets, err := GetLoggedInIscsiTargets()
@@ -149,6 +183,7 @@ func loginToVolume(volume *model.Volume) (err error) {
 	} else {
 		reachablePortals, _ = getReachableDiscoveryPortals(volume.DiscoveryIPs, true)
 	}
+
 	if len(reachablePortals) == 0 {
 		return fmt.Errorf("none of the discovery portals provided [%+v] are reachable", volume.DiscoveryIPs)
 	}
@@ -167,6 +202,7 @@ func loginToVolume(volume *model.Volume) (err error) {
 	}
 
 	// login to all targets for given volume
+
 	for _, target := range volume.TargetNames() {
 		if volume.Chap == nil {
 			err = loginToTarget(discoveredTargets, target, ifaces, "", "", volume.ConnectionMode)
@@ -187,6 +223,44 @@ func HandleIscsiDiscovery(volume *model.Volume) (err error) {
 	log.Tracef(">>>>> HandleIscsiDiscovery for volume %s, lun %s", volume.SerialNumber, volume.LunID)
 	defer log.Tracef("<<<<< HandleIscsiDiscovery")
 
+	// Do iscsi discovery for Primary Backend
+
+	var primaryVolObj *model.Volume
+	primaryVolObj = &model.Volume{}
+	primaryVolObj.LunID = volume.LunID
+	primaryVolObj.Iqns = volume.Iqns
+	primaryVolObj.TargetScope = volume.TargetScope
+	primaryVolObj.DiscoveryIPs = volume.DiscoveryIPs
+	primaryVolObj.Chap = volume.Chap
+	primaryVolObj.ConnectionMode = volume.ConnectionMode
+	primaryVolObj.SerialNumber = volume.SerialNumber
+
+	err = handleIscsiDiscoveryForBackend(primaryVolObj, true)
+
+	if err != nil {
+		return err
+	}
+	secondaryBackends := util.GetSecondaryBackends(volume.SecondaryArrayDetails)
+
+	for _, secondaryLunInfo := range secondaryBackends {
+		// Do iscsi discovery for Each Secondary Backend
+		var secondaryVolObj *model.Volume
+		secondaryVolObj = &model.Volume{}
+		secondaryVolObj.LunID = strconv.Itoa(int(secondaryLunInfo.LunID))
+		secondaryVolObj.Iqns = secondaryLunInfo.TargetNames
+		secondaryVolObj.TargetScope = volume.TargetScope
+		secondaryVolObj.DiscoveryIPs = secondaryLunInfo.DiscoveryIPs
+		secondaryVolObj.Chap = volume.Chap
+		secondaryVolObj.ConnectionMode = volume.ConnectionMode
+		secondaryVolObj.SerialNumber = volume.SerialNumber
+
+		err = handleIscsiDiscoveryForBackend(secondaryVolObj, true)
+	}
+	return nil
+}
+func handleIscsiDiscoveryForBackend(volume *model.Volume, isPrimaryBackend bool) (err error) {
+	log.Tracef(">>>>> handleIscsiDiscoveryForBackend for volume obj : %v, isPrimary %v", volume, isPrimaryBackend)
+	defer log.Tracef("<<<<< handleIscsiDiscoveryForBackend")
 	// determine if all required targets are already logged-in
 	loggedIn, err := areTargetsLoggedIn(volume.TargetNames())
 	if err != nil {
@@ -195,6 +269,9 @@ func HandleIscsiDiscovery(volume *model.Volume) (err error) {
 
 	if !loggedIn {
 		loginToVolume(volume)
+	} else {
+		// update chap info for already loggedIn targets
+		updateChapForLoggedInTargets(volume)
 	}
 
 	// single-target-single-lun models doesn't require SCSI resan to be performed
@@ -208,6 +285,7 @@ func HandleIscsiDiscovery(volume *model.Volume) (err error) {
 		log.Errorf("Unable to rescan iscsi hosts, Error: %s", err.Error())
 		return fmt.Errorf("Unable to rescan iscsi hosts, Error: %s", err.Error())
 	}
+
 	return nil
 }
 
@@ -218,32 +296,15 @@ func loginToTarget(targets model.IscsiTargets, targetIqn string, ifaces []*model
 		log.Traceln("Checking with TargetName:", target.Name)
 		if target.Name == targetIqn {
 			log.Debug("Found target :", "Target:", targetIqn)
-			// Update Chap credentials
-			if chapUser != "" && chapPassword != "" {
-				err = updateChapUser(target, chapUser)
-				if err != nil {
-					return err
-				}
-				err = updateChapPassword(target, chapPassword)
-				if err != nil {
-					return err
-				}
-			}
 			// Now login to the target
-			err := addTarget(target, ifaces)
+			err := addTarget(target, ifaces, chapUser, chapPassword, connectionMode)
 			if err != nil {
 				if !strings.Contains(err.Error(), alreadyPresent) {
 					err = fmt.Errorf("Unable to login to iscsi target %s. Error: %s", target.Name, err.Error())
 					log.Error(err.Error())
-					return err
+					// continue with other targets even if there is an error
 				}
 			}
-			if connectionMode != "" {
-				updateConnectionMode(target, targets, connectionMode)
-			} else {
-				log.Tracef("using node.startup=automatic for %s", target.Name)
-			}
-			break
 		}
 	}
 	return nil
@@ -300,12 +361,9 @@ func isReachable(initiatorIP, targetIP string) (reachable bool, err error) {
 	return true, nil
 }
 
-func updateConnectionMode(target *model.IscsiTarget, targets model.IscsiTargets, connectionMode string) {
+func updateConnectionMode(target *model.IscsiTarget, connectionMode string) {
 	log.Tracef(">>>>> updateConnectionMode for target %s mode %s", target.Name, connectionMode)
 	defer log.Trace("<<<<< updateConnectionMode")
-
-	iscsiMutex.Lock()
-	defer iscsiMutex.Unlock()
 
 	if !(connectionMode == "automatic" || connectionMode == "manual") {
 		err := fmt.Errorf("unsupported iscsi connection mode %s", connectionMode)
@@ -313,30 +371,23 @@ func updateConnectionMode(target *model.IscsiTarget, targets model.IscsiTargets,
 		return
 	}
 
-	for _, t := range targets {
-		if t.Name != target.Name {
-			continue
-		}
-		log.Tracef("updating node.startup for target %s address %s", t.Name, t.Address)
-		// update connection mode of all targets with same target name
-		args := []string{"--mode", "node", "--targetname", t.Name, "--portal", t.Address, "--op", "update", "-n", "node.startup", "-v", connectionMode}
-		_, _, err := util.ExecCommandOutput(iscsicmd, args)
-		if err != nil {
-			err = fmt.Errorf("Unable to update node.startup to %s for node %s error %s", connectionMode, t.Name, err.Error())
-			log.Errorf(err.Error())
-		}
+	log.Tracef("updating node.startup for target %s address %s", target.Name, target.Address)
+	// update connection mode of all targets with same target name
+	args := []string{"--mode", "node", "--targetname", target.Name, "--portal", target.Address, "--op", "update", "-n", "node.startup", "-v", connectionMode}
+	_, _, err := util.ExecCommandOutput(iscsicmd, args)
+	if err != nil {
+		err = fmt.Errorf("Unable to update node.startup to %s for node %s error %s", connectionMode, target.Name, err.Error())
+		log.Errorf(err.Error())
 	}
 	return
 }
 
 // updates iscsi node db with given chap username
 func updateChapUser(target *model.IscsiTarget, chapUser string) (err error) {
-	log.Tracef(">>>>> updateChapUser for target %s user %s", target.Name, chapUser)
+	log.Tracef(">>>>> updateChapUser for target %s portal %s, user %s", target.Name, target.Address, chapUser)
 	defer log.Trace("<<<<< updateChapUser")
 
-	iscsiMutex.Lock()
-	defer iscsiMutex.Unlock()
-
+	// update nodeChapUser of all targets with same target name
 	args := []string{"--mode", "node", "--targetname", target.Name, "--portal", target.Address, "--op", "update", "-n", nodeChapUser, "-v", chapUser}
 	_, _, err = util.ExecCommandOutput(iscsicmd, args)
 	if err != nil {
@@ -348,32 +399,40 @@ func updateChapUser(target *model.IscsiTarget, chapUser string) (err error) {
 
 // updates iscsi node db with given chap password
 func updateChapPassword(target *model.IscsiTarget, chapPassword string) (err error) {
-	log.Tracef(">>>>> updateChapPassword for target %s", target.Name)
+	log.Tracef(">>>>> updateChapPassword for target %s portal %s", target.Name, target.Address)
 	defer log.Trace("<<<<< updateChapPassword")
 
-	iscsiMutex.Lock()
-	defer iscsiMutex.Unlock()
-
-	log.Tracef("updateChapPassword called for target %s", target.Name)
+	// update nodeChapPassword of all targets with same target name
 	args := []string{"--mode", "node", "--targetname", target.Name, "--portal", target.Address, "--op", "update", "-n", nodeChapPassword, "-v", chapPassword}
 	_, _, err = util.ExecCommandOutput(iscsicmd, args)
 	if err != nil {
-		log.Errorf("Unable to update chap username for node %s error %s", target.Name, err.Error())
-		return fmt.Errorf("Unable to update chap username for node %s error %s", target.Name, err.Error())
+		log.Errorf("Unable to update chap password for node %s address %s error %s", target.Name, target.Address, err.Error())
+		return fmt.Errorf("Unable to update chap password for node %s error %s", target.Name, err.Error())
 	}
 	return nil
 }
 
 // addTarget : adds iscsi target to iscsi database
-func addTarget(target *model.IscsiTarget, ifaces []*model.Iface) (err error) {
+func addTarget(target *model.IscsiTarget, ifaces []*model.Iface, chapUser, chapPassword, connectionMode string) (err error) {
 	log.Tracef(">>>>> addTarget called with target: %s address: %s port: %s", target.Name, target.Address, target.Port)
 	defer log.Trace("<<<<< addTarget")
 
 	iscsiMutex.Lock()
 	defer iscsiMutex.Unlock()
 
+	// update chapuser irrespective (could be a toggle case chap->empty)
+	err = updateChapUser(target, chapUser)
+	if err != nil {
+		log.Errorf(err.Error())
+	}
+	err = updateChapPassword(target, chapPassword)
+	if err != nil {
+		log.Errorf(err.Error())
+	}
+
 	var out string
-	args := []string{"--mode", "node", "--targetname", target.Name, "--login"}
+	args := []string{"--mode", "node", "--targetname", target.Name, "--portal", target.Address, "--login"}
+
 	if len(ifaces) > 0 {
 		for _, iface := range ifaces {
 			// verify if the target is reachable from this interface
@@ -404,6 +463,14 @@ func addTarget(target *model.IscsiTarget, ifaces []*model.Iface) (err error) {
 		}
 		log.Trace("addTarget Response :", out)
 	}
+
+	// update connection
+	if connectionMode != "" {
+		updateConnectionMode(target, connectionMode)
+	} else {
+		log.Tracef("using node.startup=automatic for %s", target.Name)
+	}
+
 	if err != nil {
 		return fmt.Errorf("Unable to add login to iscsi target %s. Error: %s", target.Name, err.Error())
 	}
@@ -498,6 +565,7 @@ func GetLoggedInIscsiTargets() (targets []string, err error) {
 	}
 	for _, session := range sessions {
 		targetPath := fmt.Sprintf("/sys/class/iscsi_session/%s/targetname", session.Name())
+		//TODO : check session state
 		exists, _, _ := util.FileExists(targetPath)
 		if exists {
 			targetName, err := ioutil.ReadFile(targetPath)
@@ -636,6 +704,40 @@ func validateChapUserPassword(user []string, password []string) (chapInfo *model
 	}
 	chapInfo = &model.ChapInfo{Name: user[0], Password: password[0]}
 	return chapInfo, nil
+}
+
+// GetIscsiNodesFromIsciadm retrieves iscsi targets with iscsiadm command
+func GetIscsiNodesFromIsciadm() (a model.IscsiTargets, err error) {
+	log.Tracef(">>>>> GetIscsiNodesFromIsciadm called")
+	defer log.Trace("<<<<< GetIscsiNodesFromIsciadm")
+	var out string
+	var outList []string
+	args := []string{"-m", "node"}
+	out, _, _ = util.ExecCommandOutput(iscsicmd, args)
+	if err != nil {
+		log.Error(err.Error())
+	}
+	outList = append(outList, out)
+	log.Trace(outList)
+	var iscsiTargets model.IscsiTargets
+	// parse the lines into output
+	r := regexp.MustCompile(getIscsiadmPattern())
+
+	for _, outItem := range outList {
+		listOut := r.FindAllString(outItem, -1)
+		for _, line := range listOut {
+			result := util.FindStringSubmatchMap(line, r)
+			target := &model.IscsiTarget{
+				Name:    result["target"],
+				Address: result["address"],
+				Port:    result["port"],
+			}
+			log.Tracef("Name %s Address %s Port %s", target.Name, target.Address, target.Port)
+			iscsiTargets = append(iscsiTargets, target)
+		}
+	}
+	uniqueIscsiTargets := removeDuplicateTargets(iscsiTargets)
+	return uniqueIscsiTargets, err
 }
 
 // PerformDiscovery : adds iscsi targets to iscsi database after performing
@@ -898,6 +1000,7 @@ func rescanIscsiHosts(iscsiHosts []string, lunID string) (err error) {
 					log.Tracef("error writing to file %s : %s", iscsiHostScanPath, err.Error())
 				}
 			} else {
+				log.Printf("\n SCANNING iscsi lun id %v", lunID)
 				err = ioutil.WriteFile(iscsiHostScanPath, []byte("- - "+lunID), 0644)
 				if err != nil {
 					log.Tracef("error writing to file %s : %s", iscsiHostScanPath, err.Error())
@@ -985,4 +1088,3 @@ func bindIface(network model.NetworkInterface) error {
 	}
 	return nil
 }
-

--- a/vendor/github.com/hpe-storage/common-host-libs/linux/mount.go
+++ b/vendor/github.com/hpe-storage/common-host-libs/linux/mount.go
@@ -212,7 +212,7 @@ func CreateFileSystemOnDevice(serialnumber string, fileSystemType string) (dev *
 	log.Tracef("CreateFileSystemOnDevice called with :%s %s", serialnumber, fileSystemType)
 	var devices []*model.Device
 	for i := 1; i <= countdownTicker; i++ {
-		devices, err = GetLinuxDmDevices(true, serialnumber, "")
+		devices, err = GetLinuxDmDevices(true, util.GetVolumeObject(serialnumber, ""))
 		if err != nil {
 			log.Debugf("error to retrieve active paths for %s, retrying, count=%d", serialnumber, i)
 			continue

--- a/vendor/github.com/hpe-storage/common-host-libs/model/types.go
+++ b/vendor/github.com/hpe-storage/common-host-libs/model/types.go
@@ -166,33 +166,34 @@ type DevicePartition struct {
 
 // Volume : Thin version of Volume object for Host side
 type Volume struct {
-	ID             string                 `json:"id,omitempty"`
-	Name           string                 `json:"name,omitempty"`
-	Size           int64                  `json:"size,omitempty"` // size in bytes
-	Description    string                 `json:"description,omitempty"`
-	InUse          bool                   `json:"in_use,omitempty"` // deprecated for published in the CSP implementation
-	Published      bool                   `json:"published,omitempty"`
-	BaseSnapID     string                 `json:"base_snapshot_id,omitempty"`
-	ParentVolID    string                 `json:"parent_volume_id,omitempty"`
-	Clone          bool                   `json:"clone,omitempty"`
-	Config         map[string]interface{} `json:"config,omitempty"`
-	Metadata       []*KeyValue            `json:"metadata,omitempty"`
-	SerialNumber   string                 `json:"serial_number,omitempty"`
-	AccessProtocol string                 `json:"access_protocol,omitempty"`
-	Iqn            string                 `json:"iqn,omitempty"` // deprecated
-	Iqns           []string               `json:"iqns,omitempty"`
-	DiscoveryIP    string                 `json:"discovery_ip,omitempty"` // deprecated
-	DiscoveryIPs   []string               `json:"discovery_ips,omitempty"`
-	MountPoint     string                 `json:"Mountpoint,omitempty"`
-	Status         map[string]interface{} `json:"status,omitempty"` // interface so that we can map any number of arguments
-	Chap           *ChapInfo              `json:"chap_info,omitempty"`
-	Networks       []*NetworkInterface    `json:"networks,omitempty"`
-	ConnectionMode string                 `json:"connection_mode,omitempty"`
-	LunID          string                 `json:"lun_id,omitempty"`
-	TargetScope    string                 `json:"target_scope,omitempty"` //GST="group", VST="volume" or empty(older array fiji etc), and no-op for FC
-	IscsiSessions  []*IscsiSession        `json:"iscsi_sessions,omitempty"`
-	FcSessions     []*FcSession           `json:"fc_sessions,omitempty"`
-	VolumeGroupId  string                 `json:"volume_group_id"`
+	ID                    string                 `json:"id,omitempty"`
+	Name                  string                 `json:"name,omitempty"`
+	Size                  int64                  `json:"size,omitempty"` // size in bytes
+	Description           string                 `json:"description,omitempty"`
+	InUse                 bool                   `json:"in_use,omitempty"` // deprecated for published in the CSP implementation
+	Published             bool                   `json:"published,omitempty"`
+	BaseSnapID            string                 `json:"base_snapshot_id,omitempty"`
+	ParentVolID           string                 `json:"parent_volume_id,omitempty"`
+	Clone                 bool                   `json:"clone,omitempty"`
+	Config                map[string]interface{} `json:"config,omitempty"`
+	Metadata              []*KeyValue            `json:"metadata,omitempty"`
+	SerialNumber          string                 `json:"serial_number,omitempty"`
+	AccessProtocol        string                 `json:"access_protocol,omitempty"`
+	Iqn                   string                 `json:"iqn,omitempty"` // deprecated
+	Iqns                  []string               `json:"iqns,omitempty"`
+	DiscoveryIP           string                 `json:"discovery_ip,omitempty"` // deprecated
+	DiscoveryIPs          []string               `json:"discovery_ips,omitempty"`
+	MountPoint            string                 `json:"Mountpoint,omitempty"`
+	Status                map[string]interface{} `json:"status,omitempty"` // interface so that we can map any number of arguments
+	Chap                  *ChapInfo              `json:"chap_info,omitempty"`
+	Networks              []*NetworkInterface    `json:"networks,omitempty"`
+	ConnectionMode        string                 `json:"connection_mode,omitempty"`
+	LunID                 string                 `json:"lun_id,omitempty"`
+	TargetScope           string                 `json:"target_scope,omitempty"` //GST="group", VST="volume" or empty(older array fiji etc), and no-op for FC
+	IscsiSessions         []*IscsiSession        `json:"iscsi_sessions,omitempty"`
+	FcSessions            []*FcSession           `json:"fc_sessions,omitempty"`
+	VolumeGroupId         string                 `json:"volume_group_id"`
+	SecondaryArrayDetails string                 `json:"secondary_array_details,omitempty"`
 }
 
 func (v Volume) TargetNames() []string {
@@ -285,6 +286,19 @@ type BlockDeviceAccessInfo struct {
 	AccessProtocol string   `json:"access_protocol,omitempty"`
 	TargetNames    []string `json:"target_names,omitempty"`
 	LunID          int32    `json:"lun_id,omitempty"`
+	SecondaryBackendDetails
+	IscsiAccessInfo
+}
+
+// Information of LUN id, IQN, discovery IP's the secondary array
+type SecondaryBackendDetails struct {
+	PeerArrayDetails []*SecondaryLunInfo
+}
+
+// Information of the each secondary array
+type SecondaryLunInfo struct {
+	LunID       int32    `json:"lun_id,omitempty""`
+	TargetNames []string `json:"target_names,omitempty"`
 	IscsiAccessInfo
 }
 

--- a/vendor/github.com/hpe-storage/common-host-libs/tunelinux/config.go
+++ b/vendor/github.com/hpe-storage/common-host-libs/tunelinux/config.go
@@ -266,7 +266,7 @@ func GetRecommendations() (settings []*Recommendation, err error) {
 	var fcRecommendations []*Recommendation
 
 	// Get all nimble devices
-	devices, err := linux.GetLinuxDmDevices(false, "", "")
+	devices, err := linux.GetLinuxDmDevices(false, util.GetVolumeObject("", ""))
 	if err != nil {
 		log.Error("Unable to get Nimble devices ", err.Error())
 		return nil, err

--- a/vendor/github.com/hpe-storage/common-host-libs/tunelinux/disk.go
+++ b/vendor/github.com/hpe-storage/common-host-libs/tunelinux/disk.go
@@ -132,7 +132,7 @@ func GetDeviceRecommendations(devices []*model.Device) (settings []*Recommendati
 
 func updateUdevRule() (err error) {
 	// Get all nimble devices
-	devices, err := linux.GetLinuxDmDevices(true, "", "")
+	devices, err := linux.GetLinuxDmDevices(true, util.GetVolumeObject("", ""))
 	if err != nil {
 		log.Error("Unable to get Nimble devices ", err.Error())
 		return err

--- a/vendor/github.com/hpe-storage/common-host-libs/util/strings.go
+++ b/vendor/github.com/hpe-storage/common-host-libs/util/strings.go
@@ -3,6 +3,8 @@
 package util
 
 import (
+	"bytes"
+	"fmt"
 	"regexp"
 	"strings"
 )
@@ -29,4 +31,18 @@ func ToCamelCase(str string) string {
 		return ""
 	}
 	return strings.ToLower(camelCase[:1]) + camelCase[1:]
+}
+
+// ConvertArrayOfIntToString converts a given list of integer to comma separated string value
+func ConvertArrayOfIntToString(lun_ids []int32) string {
+	var buffer bytes.Buffer
+
+	for i := 0; i < len(lun_ids); i++ {
+		if i == (len(lun_ids) - 1) {
+			buffer.WriteString(fmt.Sprintf("%d", lun_ids[i]))
+		} else {
+			buffer.WriteString(fmt.Sprintf("%d,", lun_ids[i]))
+		}
+	}
+	return buffer.String()
 }

--- a/vendor/github.com/hpe-storage/common-host-libs/util/volume.go
+++ b/vendor/github.com/hpe-storage/common-host-libs/util/volume.go
@@ -1,0 +1,93 @@
+// Copyright 2020 Hewlett Packard Enterprise Development LP
+
+package util
+
+import (
+	"encoding/json"
+	"github.com/hpe-storage/common-host-libs/logger"
+	"github.com/hpe-storage/common-host-libs/model"
+)
+
+func GetVolumeObject(serialNumber, lunID string) *model.Volume {
+	logger.Tracef(">>>>> GetVolumeObject %s, %s", serialNumber, lunID)
+	defer logger.Tracef("<<<< GetVolumeObject")
+	var volObj *model.Volume
+	volObj = &model.Volume{}
+	volObj.SerialNumber = serialNumber
+	volObj.LunID = lunID
+
+	return volObj
+}
+
+func GetSecondaryArrayLUNIds(details string) []int32 {
+	logger.Tracef(">>>>> GetSecondaryArrayLUNIds %s", details)
+	defer logger.Tracef("<<<< GetSecondaryArrayLUNIds")
+	var secondaryArrayDetails model.SecondaryBackendDetails
+	logger.Tracef("\n About to unmarshal %s", details)
+	err := json.Unmarshal([]byte(details), &secondaryArrayDetails)
+	if err != nil {
+		logger.Errorf("\n Error in GetSecondaryArrayLUNIds %s", err.Error())
+		return []int32{}
+	}
+	numberOfSecondaryBackends := len(secondaryArrayDetails.PeerArrayDetails)
+	var secondaryLunIds []int32 = make([]int32, numberOfSecondaryBackends)
+	for i := 0; i < numberOfSecondaryBackends; i++ {
+		secondaryLunIds[i] = secondaryArrayDetails.PeerArrayDetails[i].LunID
+	}
+	return secondaryLunIds
+}
+
+func GetSecondaryArrayTargetNames(details string) []string {
+	logger.Tracef(">>>>> GetSecondaryArrayTargetNames %s", details)
+	defer logger.Tracef("<<<< GetSecondaryArrayTargetNames")
+	var secondaryArrayDetails model.SecondaryBackendDetails
+	logger.Tracef("\n About to unmarshal %s", details)
+	err := json.Unmarshal([]byte(details), &secondaryArrayDetails)
+	if err != nil {
+		logger.Errorf("\n Error in GetSecondaryArrayTargetNames %s", err.Error())
+		return []string{}
+	}
+	numberOfSecondaryBackends := len(secondaryArrayDetails.PeerArrayDetails)
+	var secondaryTargetNames []string
+	for i := 0; i < numberOfSecondaryBackends; i++ {
+		for _, targetNameRetrieved := range secondaryArrayDetails.PeerArrayDetails[i].TargetNames {
+			secondaryTargetNames = append(secondaryTargetNames, targetNameRetrieved)
+		}
+	}
+	return secondaryTargetNames
+}
+
+func GetSecondaryArrayDiscoveryIps(details string) []string {
+	logger.Tracef(">>>>> GetSecondaryArrayDiscoveryIps %s", details)
+	defer logger.Tracef("<<<< GetSecondaryArrayDiscoveryIps")
+	var secondaryArrayDetails model.SecondaryBackendDetails
+	logger.Tracef("\n About to unmarshal %s", details)
+	err := json.Unmarshal([]byte(details), &secondaryArrayDetails)
+	if err != nil {
+		logger.Errorf("\n Error in GetSecondaryArrayDiscoveryIps %s", err.Error())
+		return []string{}
+	}
+	numberOfSecondaryBackends := len(secondaryArrayDetails.PeerArrayDetails)
+	var secondaryDiscoverIps []string
+	for i := 0; i < numberOfSecondaryBackends; i++ {
+		for _, discoveryIpRetrieved := range secondaryArrayDetails.PeerArrayDetails[i].DiscoveryIPs {
+			secondaryDiscoverIps = append(secondaryDiscoverIps, discoveryIpRetrieved)
+		}
+	}
+	return secondaryDiscoverIps
+}
+
+func GetSecondaryBackends(details string) []*model.SecondaryLunInfo {
+	logger.Tracef(">>>>> GetSecondaryBackends %s", details)
+	defer logger.Tracef("<<<< GetSecondaryBackends")
+	var secondaryArrayDetails model.SecondaryBackendDetails
+	logger.Tracef("\n About to unmarshal %s", details)
+	err := json.Unmarshal([]byte(details), &secondaryArrayDetails)
+	if err != nil {
+		logger.Errorf("\n Error in GetSecondaryBackends %s", err.Error())
+		logger.Errorf("\n Passed details %s", details)
+		return nil
+	}
+	return secondaryArrayDetails.PeerArrayDetails
+
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -72,7 +72,7 @@ github.com/hpcloud/tail/ratelimiter
 github.com/hpcloud/tail/util
 github.com/hpcloud/tail/watch
 github.com/hpcloud/tail/winfile
-# github.com/hpe-storage/common-host-libs v4.2.1-0.20200706204556-55cdf4356dfa+incompatible
+# github.com/hpe-storage/common-host-libs v4.2.1-0.20200724035537-cf0f6aa92d3d+incompatible
 github.com/hpe-storage/common-host-libs/chapi
 github.com/hpe-storage/common-host-libs/concurrent
 github.com/hpe-storage/common-host-libs/connectivity


### PR DESCRIPTION
This PR has a dependency on common-host-libs PR -- https://github.com/hpe-storage/common-host-libs/pull/126 
Please merge the common-host-libs PR first, and then this.

- Requirement

    - Current in 3PAR/Primera CSP we are adding requirement for Peer persistence based Replication, where we need to create host and vlun's for both the Primary (source) array and the Target (secondary) array, so that the multipath device mapping will have paths from active/passive arrays. But, the publish volume response from CSP to CSI has currently support for only returning a single lun id. The change here is to return a object called SecondaryArrayDetails which will have list of object PeerDetails which has lun id, discovery ip, target names etc. One PeerDetail will be created per secondary backend.


- Approach

Changes are done to find, if the multiple luns are passed based on the number of PeerDetails in SecondaryArrayDetails struct. iscsi login , scanning all takes care of reading this object, and invokes appropriate actions.

Signed-off-by: William Durairaj <w_durairaj@yahoo.com>