### PR TITLE
Conform with Fedora CoreOS

### DIFF
--- a/cmd/csi-driver/conform/hpe-storage-node.sh
+++ b/cmd/csi-driver/conform/hpe-storage-node.sh
@@ -20,7 +20,7 @@ if [ -f /etc/os-release ]; then
     if [ $? -eq 0 ]; then
         CONFORM_TO=ubuntu
     fi
-    echo $os_name | egrep -i "CoreOS" >> /dev/null 2>&1
+    echo $os_name | egrep -i "CoreOS|Fedora" >> /dev/null 2>&1
     if [ $? -eq 0 ]; then
         CONFORM_TO=coreos
     fi


### PR DESCRIPTION
Fedora CoreOS does not identify itself as "CoreOS", but as "Fedora". As the conformance check does nothing on coreos it is worth it to have on Fedora CoreOS but also does not create any issues with a Fedora distribution.