### PR TITLE
Update deployment strategy as "Recreate" instead of "RollingUpgrade" for NFS to avoid duplicate pods running on upgrades momentarily

### DIFF
--- a/pkg/flavor/kubernetes/nfs.go
+++ b/pkg/flavor/kubernetes/nfs.go
@@ -804,6 +804,7 @@ func (flavor *Flavor) makeNFSDeployment(name string, nfsSpec *NFSSpec, nfsNamesp
 			},
 			Template: podSpec,
 			Replicas: int32toPtr(1),
+			Strategy: apps_v1.DeploymentStrategy{Type: apps_v1.RecreateDeploymentStrategyType},
 		},
 	}
 	return d


### PR DESCRIPTION

Signed-off-by: Shiva Krishna, Merla <shivakrishna.merla@hpe.com>