### PR TITLE
Update the conform script to include Amazon for installing iscsi

### DIFF
--- a/cmd/csi-driver/conform/hpe-storage-node.sh
+++ b/cmd/csi-driver/conform/hpe-storage-node.sh
@@ -12,7 +12,7 @@ exit_on_error() {
 if [ -f /etc/os-release ]; then
     os_name=$(cat /etc/os-release | egrep "^NAME=" | awk -F"NAME=" '{print $2}')
     echo "os name obtained as $os_name"
-    echo $os_name | egrep -i "Red Hat|CentOS" >> /dev/null 2>&1
+    echo $os_name | egrep -i "Red Hat|CentOS|Amazon Linux" >> /dev/null 2>&1
     if [ $? -eq 0 ]; then
         CONFORM_TO=redhat
     fi


### PR DESCRIPTION
Signed-off-by: chaitra <chaitra.kallianpur@hpe.com>
On Amazon EKS, the default EC2 node is set up using Amazon Linux, so it fails this install step. It can be fixed by adding Amazon Linux to the "Redhat | CentOS" check, since it is based on those and provides the necessary packages for iscsi.