### PR TITLE
Fix pvc resize issue on k8s 119

### DIFF
--- a/pkg/driver/node_server.go
+++ b/pkg/driver/node_server.go
@@ -1715,13 +1715,11 @@ func (driver *Driver) NodeExpandVolume(ctx context.Context, request *csi.NodeExp
 		// figure out if volumePath is actually a staging path
 		stagedDevice, err := readStagedDeviceInfo(request.GetVolumePath())
 		if err != nil {
-			log.Tracef("Error retrieving stagedDevice from volume path %v",request.GetVolumePath())
-			log.Tracef(" Retrying with staged target path %v",request.GetStagingTargetPath())
 			// See if the "staging_target_path contains the deviceInfo.json
 			// This behaviour is peculiar to only k8s 1.19
 			stagedDevice, err = readStagedDeviceInfo(request.GetStagingTargetPath())
 			if err != nil {
-				return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("Cannot get staging device info from volume path %s", err.Error()))
+				return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("Cannot get staging device info from volume path %s, staged location %s, Error : %s", request.GetVolumePath(), request.GetStagingTargetPath(), err.Error()))
 			}
 		}
 		if stagedDevice == nil || stagedDevice.Device == nil {

--- a/pkg/driver/node_server.go
+++ b/pkg/driver/node_server.go
@@ -1715,7 +1715,14 @@ func (driver *Driver) NodeExpandVolume(ctx context.Context, request *csi.NodeExp
 		// figure out if volumePath is actually a staging path
 		stagedDevice, err := readStagedDeviceInfo(request.GetVolumePath())
 		if err != nil {
-			return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("Cannot get staging device info from volume path %s", err.Error()))
+			log.Tracef("Error retrieving stagedDevice from volume path %v",request.GetVolumePath())
+			log.Tracef(" Retrying with staged target path %v",request.GetStagingTargetPath())
+			// See if the "staging_target_path contains the deviceInfo.json
+			// This behaviour is peculiar to only k8s 1.19
+			stagedDevice, err = readStagedDeviceInfo(request.GetStagingTargetPath())
+			if err != nil {
+				return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("Cannot get staging device info from volume path %s", err.Error()))
+			}
 		}
 		if stagedDevice == nil || stagedDevice.Device == nil {
 			return nil, status.Error(codes.Internal,


### PR DESCRIPTION
## Problem
Online volume expansion in k8s 1.19 fails with an error stating to restart pod when the underlying PVC is edited for size (volume expansion)

## Analysis
  - There is a change in behaviour in k8s 1.19, where the `NodeExpandVolume` can be triggered after `NodePublishVolume` as documented in https://github.com/kubernetes/kubernetes/pull/86968
  - `volumePath` which was originally computed in the node plugin code, can now point to a location where the pod's volume is currently published, instead of the path of the staged location.
 - Fix is to find the volumePath and if the path is not found (which is internally used for finding a file `deviceInfo.json`) , then the code falls back to staged volume path.
 - Could have used the staging path directly instead of a fall back logic, but this was a working code in earlier k8s releases, and hence followed a safe approach to do a fallback, since this is the new field `staging_target_path` field is send in request of `NodeExpandVolume`

## Log analysis
```
k8s 1.19

time="2020-10-22T12:18:35Z" level=info msg="GRPC request: {\"capacity_range\":{\"required_bytes\":31138512896},\"staging_target_path\":\"/var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-ddf51066-8d06-475f-9a0e-e1908743285d/globalmount\",\"volume_capability\":{\"AccessType\":{\"Mount\":{\"fs_type\":\"ext4\"}},\"access_mode\":{\"mode\":1}},\"volume_id\":\"pvc-ddf51066-8d06-475f-9a0e-e1908743285d\",\"volume_path\":\"/var/lib/kubelet/pods/5981ce0e-a1e9-4e84-9dfb-0ae3991233ab/volumes/kubernetes.io~csi/pvc-ddf51066-8d06-475f-9a0e-e1908743285d/mount\"}" file="utils.go:70"


====

k8s 1.16

time="2020-10-22T13:03:15Z" level=info msg="GRPC call: /csi.v1.Node/NodeExpandVolume" file="utils.go:69"
time="2020-10-22T13:03:15Z" level=info msg="GRPC request: {\"capacity_range\":{\"required_bytes\":33285996544},\"volume_id\":\"pvc-197caf3e-f210-4a43-968d-48783dd594d0\",\"volume_path\":\"/var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-197caf3e-f210-4a43-968d-48783dd594d0/globalmount\"}" file="utils.go:70"
time="2020-10-22T13:03:15Z" level=info msg="About to expand device /var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-197caf3e-f210-4a43-968d-48783dd594d0/globalmount with access type mount to underlying volume size" file="node_server.go:1733"


```
You can see the difference in the request for `volume_path` in k8s 1.19 vs earlier versions.

Additional details
```
[root@cld13b11-worker2 log]# ls -l /var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-ddf51066-8d06-475f-9a0e-e1908743285d/globalmount/deviceInfo.json
-rw-------. 1 root root 547 Oct 22 07:52 /var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-ddf51066-8d06-475f-9a0e-e1908743285d/globalmount/deviceInfo.json

deviceInfo.json is written here:
=============
/var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-ddf51066-8d06-475f-9a0e-e1908743285d/globalmount/deviceInfo.json


read here: 
==========

/var/lib/kubelet/pods/5981ce0e-a1e9-4e84-9dfb-0ae3991233ab/volumes/kubernetes.io~csi/pvc-ddf51066-8d06-475f-9a0e-e1908743285d/mount/deviceInfo.json


POD expansion failure indicated in k8s 1.19
============

 Warning  VolumeResizeFailed      <invalid> (x8 over <invalid>)  kubelet                  NodeExpandVolume.NodeExpandVolume failed for volume "pvc-ddf51066-8d06-475f-9a0e-e1908743285d" : Expander.NodeExpand failed to expand the volume : rpc error: code = InvalidArgument desc = Cannot get staging device info from volume path Device info file /var/lib/kubelet/pods/5981ce0e-a1e9-4e84-9dfb-0ae3991233ab/volumes/kubernetes.io~csi/pvc-ddf51066-8d06-475f-9a0e-e1908743285d/mount/deviceInfo.json does not exist


[root@cld13b11-worker2 log]# cat /var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-ddf51066-8d06-475f-9a0e-e1908743285d/globalmount/deviceInfo.json
{"volume_id":"pvc-ddf51066-8d06-475f-9a0e-e1908743285d","volume_access_mode":2,"device":{"path_name":"dm-2","serial_number":"60002ac00000000006010d5700002ba0","major":"253","minor":"2","alt_full_path_name":"/dev/mapper/mpathaji","mpath_device_name":"mpathaji","size":19456,"slaves":["sdb","sdc","sdd","sde","sdf","sdg"],"target_scope":"group","state":"active"},"mount_info":{"mount_point":"/var/lib/kubelet/plugins/hpe.com/mounts/pvc-ddf51066-8d06-475f-9a0e-e1908743285d","filesystem_options":{"Type":"ext4","Mode":"","Owner":"","CreateOpts":""}}}[root@cld13b11-worker2 log]#
```