### PR TITLE
Update UBI image to 7.9-256 to fix security vulnerability

### DIFF
--- a/cmd/csi-driver/Dockerfile
+++ b/cmd/csi-driver/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi7/ubi-minimal:7.8-328
+FROM registry.access.redhat.com/ubi7/ubi-minimal:7.9-256
 
 RUN microdnf update -y && rm -rf /var/cache/yum
 RUN microdnf install -y systemd


### PR DESCRIPTION
Update UBI image to fix 1 high security vulnerability as shown in https://quay.io/repository/hpestorage/csi-driver?tab=tags 
Note: Currently i have pushed the image, so it's green now.

Signed-off-by: William Durairaj <w_durairaj@yahoo.com>