### PR TITLE
Commented volume metrics capability in 1.4

### DIFF
--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -96,7 +96,8 @@ func NewDriver(name, version, endpoint, flavorName string, nodeService bool, dbS
 	driver.AddNodeServiceCapabilities([]csi.NodeServiceCapability_RPC_Type{
 		csi.NodeServiceCapability_RPC_STAGE_UNSTAGE_VOLUME,
 		csi.NodeServiceCapability_RPC_EXPAND_VOLUME,
-		csi.NodeServiceCapability_RPC_GET_VOLUME_STATS,
+		// TODO- Add a flag to either enable or disable flag in deployment to collect volume stats
+		//csi.NodeServiceCapability_RPC_GET_VOLUME_STATS,
 	})
 
 	// Init Volume Expansion Capabilities supported by the driver


### PR DESCRIPTION
This fix disables volume metrics capability on the csi driver.

Will raise a separate PR for 1.5 which reads bool parameter from deployment template to either run/not run the capability.

Signed-off-by: Sneha Rai <sneha.rai@hpe.com>