### PR TITLE
csi: fix build failure

### DIFF
--- a/cmd/csi-driver/Dockerfile
+++ b/cmd/csi-driver/Dockerfile
@@ -1,9 +1,8 @@
 FROM registry.access.redhat.com/ubi7/ubi-minimal:7.9-256
 
 RUN microdnf update -y && rm -rf /var/cache/yum
-RUN microdnf install -y systemd
 ADD CentOS-Base.repo /etc/yum.repos.d/
-RUN microdnf install -y cryptsetup
+RUN microdnf install -y systemd && microdnf install -y cryptsetup
 
 LABEL name="HPE CSI Driver for Kubernetes" \
       maintainer="HPE Storage" \


### PR DESCRIPTION
Problem: multi step microdnf install command throws error

error: failed to remove /var/cache/yum/metadata/updates-7Server-x86_64/repodata
The command '/bin/sh -c microdnf install -y cryptsetup' returned a non-zero code: 1

Signed-off-by: Raunak <raunak.kumar@hpe.com>