### PR TITLE
Added encryption parameters validations

### DIFF
--- a/pkg/driver/constants.go
+++ b/pkg/driver/constants.go
@@ -112,7 +112,7 @@ const (
 	sizeKey = "size"
 
 	trueKey = "true"
-
+	falseKey = "false"
 	// nfs properties
 	nfsResourcesKey = "nfsResources"
 	// indicates if this is an underlying NFS PVC(not exposed to user)


### PR DESCRIPTION
Added encryption parameters validations as per the cases mentioned in PR#246

hostEncryption must be true/false any other value should throw error . 
hostEncryptionName/hostEncryptionNamespace both must be specified with a valid value for volume encryption
handled the scenarios when hostEncryption is not specified, true, false, invalid values 
@sneharai4 @raunakkumar @datamattsson , @rgcostea Request you to review