### PR TITLE
csi: update podsDirPath needed for scrubber to use KubeletRootDir

### DIFF
--- a/pkg/driver/constants.go
+++ b/pkg/driver/constants.go
@@ -75,10 +75,6 @@ const (
 	defaultInlineVolumeScrubberInterval = 3600 // Default value is 3600 seconds or 1 Hour
 	inlineVolumeScrubberIntervalKey     = "INLINE_VOLUMES_SCRUBBER_INTERVAL"
 
-	// Default pods directory path on the node for Kubernetes/Openshift
-	defaultPodsDirPath = "/var/lib/kubelet/pods"
-	podsDirPathKey     = "PODS_DIR_PATH"
-
 	// Pending :
 	Pending = "PENDING"
 

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -193,12 +193,8 @@ func (driver *Driver) StartScrubber(nodeService bool) chan bool {
 			scrubberInterval = defaultInlineVolumeScrubberInterval
 			log.Tracef("Using defaultInlineVolumeScrubberInterval %d", scrubberInterval)
 		}
-		// Fetch PODs directory path from env variable. If unspecified, then use default value.
-		podsDirPath := os.Getenv(podsDirPathKey)
-		if podsDirPath == "" {
-			podsDirPath = defaultPodsDirPath
-			log.Tracef("Using defaultPodsDirPath %s", podsDirPath)
-		}
+		// Fetch PODs directory path from KubeletRootDir
+		podsDirPath := driver.KubeletRootDir + "pods"
 		log.Infof("Scheduled ephemeral inline volumes scrubber task to run every %d seconds, PodsDirPath: [%s]", scrubberInterval, podsDirPath)
 		tick := time.NewTicker(time.Duration(scrubberInterval) * time.Second)
 		done := make(chan bool)


### PR DESCRIPTION
Signed-off-by: Raunak <raunak.kumar@hpe.com>