### PR TITLE
update chap on csi-driver upgrade

### DIFF
--- a/cmd/csi-driver/Dockerfile
+++ b/cmd/csi-driver/Dockerfile
@@ -7,7 +7,7 @@ RUN microdnf install -y systemd && microdnf install -y cryptsetup
 LABEL name="HPE CSI Driver for Kubernetes" \
       maintainer="HPE Storage" \
       vendor="HPE" \
-      version="1.4.0" \
+      version="2.0.0" \
       summary="HPE CSI Driver for Kubernetes" \
       description="The HPE CSI Driver for Kubernetes enables container orchestrators, such as Kubernetes and OpenShift, to manage the life-cycle of persistent storage." \
       io.k8s.display-name="HPE CSI Driver for Kubernetes" \

--- a/pkg/driver/constants.go
+++ b/pkg/driver/constants.go
@@ -49,8 +49,6 @@ const (
 	volumeAccessModeKey   = "volumeAccessMode"
 	multiInitiatorKey     = "multiInitiator"
 	defaultConnectionMode = "manual"
-	chapUserEnvKey        = "CHAP_USER"
-	chapPasswordEnvKey    = "CHAP_PASSWORD"
 	KubeletRootDirEnvKey  = "KUBELET_ROOT_DIR"
 
 	// disable the node get volumestats

--- a/pkg/driver/constants.go
+++ b/pkg/driver/constants.go
@@ -52,9 +52,9 @@ const (
 	chapUserEnvKey        = "CHAP_USER"
 	chapPasswordEnvKey    = "CHAP_PASSWORD"
 	KubeletRootDirEnvKey  = "KUBELET_ROOT_DIR"
-	
-	// disable the node get volumestats 
-	disableNodeGetVolumeStatsKey    = "DISABLE_NODE_GET_VOLUMESTATS"
+
+	// disable the node get volumestats
+	disableNodeGetVolumeStatsKey = "DISABLE_NODE_GET_VOLUMESTATS"
 
 	// deviceInfoFileName is used to store the device details in a JSON file
 	deviceInfoFileName = "deviceInfo.json"

--- a/pkg/driver/node_server.go
+++ b/pkg/driver/node_server.go
@@ -2056,8 +2056,8 @@ func (driver *Driver) nodeGetInfo() (string, error) {
 				iqns = append(iqns, &initiator.Init[i])
 				// we support only single host initiator
 				// check if CHAP credentials is set through configMap, ignore iscsid.conf reference
-				envChapUser := os.Getenv(chapUserEnvKey)
-				envChapPassword := os.Getenv(chapPasswordEnvKey)
+				envChapUser := driver.flavor.GetChapUserFromEnvironment()
+				envChapPassword := driver.flavor.GetChapPasswordFromEnvironment()
 				if envChapUser != "" && envChapPassword != "" {
 					chapUsername = envChapUser
 					chapPassword = envChapPassword

--- a/pkg/flavor/kubernetes/flavor.go
+++ b/pkg/flavor/kubernetes/flavor.go
@@ -224,12 +224,24 @@ func (flavor *Flavor) LoadNodeInfo(node *model.Node) (string, error) {
 			updateNodeRequired = true
 		}
 
+		chapUser := getChapUserFromEnvironment()
+		if !reflect.DeepEqual(nodeInfo.Spec.ChapUser, chapUser) {
+			nodeInfo.Spec.ChapUser = chapUser
+			updateNodeRequired = true
+		}
+
+		chapPassword := getChapPasswordFromEnvironment()
+		if !reflect.DeepEqual(nodeInfo.Spec.ChapPassword, chapPassword) {
+			nodeInfo.Spec.ChapPassword = chapPassword
+			updateNodeRequired = true
+		}
+
 		if !updateNodeRequired {
 			// no update needed to existing CRD
 			return node.UUID, nil
 		}
-		log.Infof("updating Node %s with iqns %v wwpns %v networks %v",
-			nodeInfo.Name, nodeInfo.Spec.IQNs, nodeInfo.Spec.WWPNs, nodeInfo.Spec.Networks)
+		log.Infof("updating Node %s with iqns %v wwpns %v networks %v chapuser %s",
+			nodeInfo.Name, nodeInfo.Spec.IQNs, nodeInfo.Spec.WWPNs, nodeInfo.Spec.Networks, nodeInfo.Spec.ChapUser)
 		_, err := flavor.crdClient.StorageV1().HPENodeInfos().Update(nodeInfo)
 		if err != nil {
 			log.Errorf("Error updating the node %s - %s\n", nodeInfo.Name, err.Error())
@@ -279,6 +291,14 @@ func getWwpnsFromNode(node *model.Node) []string {
 		wwpns = append(wwpns, *node.Wwpns[i])
 	}
 	return wwpns
+}
+
+func getChapUserFromEnvironment() string {
+	return os.Getenv("CHAP_USER")
+}
+
+func getChapPasswordFromEnvironment() string {
+	return os.Getenv("CHAP_PASSWORD")
 }
 
 func getNetworksFromNode(node *model.Node) []string {

--- a/pkg/flavor/kubernetes/flavor.go
+++ b/pkg/flavor/kubernetes/flavor.go
@@ -241,8 +241,8 @@ func (flavor *Flavor) LoadNodeInfo(node *model.Node) (string, error) {
 		}
 
 		chapPassword := flavor.GetChapPasswordFromEnvironment()
-		if !reflect.DeepEqual(nodeInfo.Spec.ChapPassword, chapPassword) {
-			nodeInfo.Spec.ChapPassword = chapPassword
+		if !reflect.DeepEqual(nodeInfo.Spec.ChapPassword, b64.StdEncoding.EncodeToString([]byte(chapPassword))) {
+			nodeInfo.Spec.ChapPassword = b64.StdEncoding.EncodeToString([]byte(chapPassword))
 			updateNodeRequired = true
 		}
 

--- a/pkg/flavor/types.go
+++ b/pkg/flavor/types.go
@@ -37,4 +37,6 @@ type Flavor interface {
 	GetOrchestratorVersion() (*version.Info, error)
 	MonitorPod(podLabelkey, podLabelvalue string) error
 	GetGroupSnapshotNameFromSnapshotName(snapshotName string) (string, error)
+	GetChapUserFromEnvironment() string
+	GetChapPasswordFromEnvironment() string
 }

--- a/pkg/flavor/vanilla/flavor.go
+++ b/pkg/flavor/vanilla/flavor.go
@@ -103,3 +103,11 @@ func (flavor *Flavor) GetOrchestratorVersion() (*version.Info, error) {
 func (flavor *Flavor) MonitorPod(podLabelkey, podLabelvalue string) error {
 	return nil
 }
+
+func (flavor *Flavor) GetChapUserFromEnvironment() string {
+	return ""
+}
+
+func (flavor *Flavor) GetChapPasswordFromEnvironment() string {
+	return ""
+}


### PR DESCRIPTION
Problem: we don't manage CRDs between releases with helm.
This leaves the hpenodeinfo crd as is between releases for chap updates
Implementation: update chap just like other hpenodeinfo params

Signed-off-by: Raunak <raunak.kumar@hpe.com>