### PR TITLE
Add Rocky Linux conformance

### DIFF
--- a/cmd/csi-driver/conform/hpe-storage-node.sh
+++ b/cmd/csi-driver/conform/hpe-storage-node.sh
@@ -12,7 +12,7 @@ exit_on_error() {
 if [ -f /etc/os-release ]; then
     os_name=$(cat /etc/os-release | egrep "^NAME=" | awk -F"NAME=" '{print $2}')
     echo "os name obtained as $os_name"
-    echo $os_name | egrep -i "Red Hat|CentOS|Amazon Linux|Oracle" >> /dev/null 2>&1
+    echo $os_name | egrep -i "Red Hat|CentOS|Amazon Linux|Oracle|Rocky Linux" >> /dev/null 2>&1
     if [ $? -eq 0 ]; then
         CONFORM_TO=redhat
     fi


### PR DESCRIPTION
HPE is backing the Rocky Linux efforts to replace CentOS. Rocky Linux is bug-for-bug compatible with RHEL and we should detect it as such.

Signed-off-by: Michael Mattsson <michael.mattsson@hpe.com>