### PR TITLE
Install XFS utils for barebone Ubuntu

### DIFF
--- a/cmd/csi-driver/conform/hpe-storage-node.sh
+++ b/cmd/csi-driver/conform/hpe-storage-node.sh
@@ -56,7 +56,7 @@ if [ "$CONFORM_TO" = "ubuntu" ]; then
     fi
 
     # Install XFS utils
-    if [ ! -f /usr/sbin/mkfs.xfs ]; then
+    if [ ! -f /sbin/mkfs.xfs ]; then
         apt-get -qq update
         apt-get -qq install -y xfsprogs
         exit_on_error $?

--- a/cmd/csi-driver/conform/hpe-storage-node.sh
+++ b/cmd/csi-driver/conform/hpe-storage-node.sh
@@ -55,6 +55,13 @@ if [ "$CONFORM_TO" = "ubuntu" ]; then
         exit_on_error $?
     fi
 
+    # Install XFS utils
+    if [ ! -f /usr/sbin/mkfs.xfs ]; then
+        apt-get -qq update
+        apt-get -qq install -y xfsprogs
+        exit_on_error $?
+    fi
+
 elif [ "$CONFORM_TO" = "redhat" ]; then
     # Install device-mapper-multipath
     if [ ! -f /sbin/multipathd ]; then


### PR DESCRIPTION
This is needed for barebone Ubuntu server distros, such as the images provided by VMware Tanzu.

Signed-off-by: Michael Mattsson <michael.mattsson@gmail.com>