### PR TITLE
Remove package default multipath.conf

### DIFF
--- a/cmd/csi-driver/conform/hpe-storage-node.sh
+++ b/cmd/csi-driver/conform/hpe-storage-node.sh
@@ -30,6 +30,10 @@ if [ -f /etc/os-release ]; then
     fi
 fi
 
+if [ ! -f /etc/multipath.conf ]; then
+    nomultipathconf=true
+fi
+
 if [ "$CONFORM_TO" = "ubuntu" ]; then
     #  Install multipath packages
     if [ ! -f /sbin/multipathd ]; then
@@ -112,6 +116,12 @@ elif [ "$CONFORM_TO" = "coreos" ]; then
 else
     echo "unsupported configuration for node package checks. os $os_name"
     exit 1
+fi
+
+# Remove multipath.conf if installed during conformance with default packages
+# Node driver will install correct multipath.conf
+if [ "$nomultipathconf" = "true" ] && [ -f /etc/multipath.conf ]; then
+	rm -f /etc/multipath.conf
 fi
 
 # Load iscsi_tcp modules, its a no-op if its already loaded


### PR DESCRIPTION
If there's no multipath.conf installed on the host at the beginning of conforming the node, any multipath.conf installed by a distro package will be deleted. A correct multipath.conf file will later installed by the node driver.

Tested:
- No multipath package installed, a correct multipath.conf gets installed by the node driver.
- Multipath package installed, but no multipath.conf exist, a correct multipath.conf gets installed by the node driver.
- Local edits made to an existing multipath.conf and restarting the node driver, the local changes persist.

Signed-off-by: Michael Mattsson <michael.mattsson@gmail.com>