### PR TITLE
add sg_inq, find binaries to chroot  for resize

### DIFF
--- a/cmd/csi-driver/Dockerfile
+++ b/cmd/csi-driver/Dockerfile
@@ -46,7 +46,9 @@ RUN ln -s /chroot/chroot-host-wrapper.sh /chroot/blkid \
     && ln -s /chroot/chroot-host-wrapper.sh /chroot/umount \
     && ln -s /chroot/chroot-host-wrapper.sh /chroot/ip \
     && ln -s /chroot/chroot-host-wrapper.sh /chroot/dmidecode \
-    && ln -s /chroot/chroot-host-wrapper.sh /chroot/dnsdomainname
+    && ln -s /chroot/chroot-host-wrapper.sh /chroot/dnsdomainname \
+    && ln -s /chroot/chroot-host-wrapper.sh /chroot/sg_inq \
+    && ln -s /chroot/chroot-host-wrapper.sh /chroot/find
 
 ENV PATH="/chroot:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 


### PR DESCRIPTION
Expander.NodeExpand failed to expand the volume : rpc error: code = Internal desc = Unable to expand device, unable to perform rescan to update device capacity for /dev/dm-0, error :command rescan-scsi-bus.sh failed with rc=1 err=WARN: /usr/bin/sg_inq not present -- please install sg3_utils
 or rescan-scsi-bus.sh might not fully work.
cat: /sys/class/scsi_host/host/proc_name: No such file or directory

Signed-off-by: Raunak <raunak.kumar@hpe.com>