### PR TITLE
Replace docker build with buildx

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hpe-storage/csi-driver
 
-go 1.19
+go 1.18
 
 require (
 	github.com/Scalingo/go-etcd-lock v3.0.1+incompatible

--- a/pkg/flavor/kubernetes/nfs.go
+++ b/pkg/flavor/kubernetes/nfs.go
@@ -49,7 +49,6 @@ const (
 	defaultPodLabelValue       = "hpe-csi"
 	nfsAffinityLabelKey        = "spread-by"
 	nfsAffinityLabelValue      = "hpe-nfs"
-	nfsPodSpecAffinityKey      = "provisioned-by"
 )
 
 // NFSSpec for creating NFS resources


### PR DESCRIPTION
- Passes e2e tests on amd64, arm64 TBD (the test suite images seems to be unavailable for arm64)
- Multi-arch images POC: https://gist.github.com/datamattsson/f6f7c7736b0243af57eee42ee0331516
- Version labels in Dockerfiles are NOT updated

Signed-off-by: Michael Mattsson <michael.mattsson@gmail.com>