### PR TITLE
CON-2568

### DIFF
--- a/pkg/driver/constants.go
+++ b/pkg/driver/constants.go
@@ -113,10 +113,11 @@ const (
 	// nfs properties
 	nfsResourcesKey = "nfsResources"
 	// indicates if this is an underlying NFS PVC(not exposed to user)
-	nfsPVCKey           = "nfsPVC"
-	nfsMountOptionsKey  = "nfsMountOptions"
-	nfsNamespaceKey     = "nfsNamespace"
-	defaultNFSNamespace = "hpe-nfs"
+	nfsPVCKey             = "nfsPVC"
+	nfsMountOptionsKey    = "nfsMountOptions"
+	nfsNamespaceKey       = "nfsNamespace"
+	nfsSourceNamespaceKey = "csi.storage.k8s.io/pvc/namespace"
+	defaultNFSNamespace   = "hpe-nfs"
 
 	// Maximum default number of volumes that controller can publish to the node.
 	defaultMaxVolPerNode = 100

--- a/pkg/driver/controller_server.go
+++ b/pkg/driver/controller_server.go
@@ -325,7 +325,11 @@ func (driver *Driver) createVolume(
 			// get nfs namespace for cleanup
 			nfsNamespace := defaultNFSNamespace
 			if namespace, ok := createParameters[nfsNamespaceKey]; ok {
-				nfsNamespace = namespace
+				if createParameters[nfsNamespaceKey] == nfsSourceNamespaceKey {
+					nfsNamespace = createParameters[nfsSourceNamespaceKey]
+				} else {
+					nfsNamespace = namespace
+				}
 			}
 
 			nfsResourceName := fmt.Sprintf("%s-%s", "hpe-nfs", strings.TrimPrefix(name, "pvc-"))

--- a/pkg/flavor/kubernetes/nfs.go
+++ b/pkg/flavor/kubernetes/nfs.go
@@ -40,6 +40,7 @@ const (
 	nfsNodeSelectorValue       = "true"
 	nfsParentVolumeIDKey       = "nfs-parent-volume-id"
 	nfsNamespaceKey            = "nfsNamespace"
+	nfsSourceNamespaceKey      = "csi.storage.k8s.io/pvc/namespace"
 	nfsProvisionerImageKey     = "nfsProvisionerImage"
 	pvcKind                    = "PersistentVolumeClaim"
 	nfsConfigFile              = "ganesha.conf"
@@ -69,7 +70,11 @@ func (flavor *Flavor) CreateNFSVolume(pvName string, reqVolSize int64, parameter
 	nfsResourceNamespace := defaultNFSNamespace
 
 	if namespace, ok := parameters[nfsNamespaceKey]; ok {
-		nfsResourceNamespace = namespace
+		if parameters[nfsNamespaceKey] == nfsSourceNamespaceKey {
+			nfsResourceNamespace = parameters[nfsSourceNamespaceKey]
+		} else {
+			nfsResourceNamespace = namespace
+		}
 	}
 	// create namespace if not already present
 	_, err = flavor.getNFSNamespace(nfsResourceNamespace)


### PR DESCRIPTION
- Allows users to set `nfsNamespace` to "csi.storage.k8s.io/pvc/namespace" and the CSI driver will replace it with the requesting `Namespace` of the `PVC`.