### PR TITLE
CON2508: Cleanup of stale multipath devices for node monitor as well as node init container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:9.4-949.1714662671
 RUN microdnf update -y && rm -rf /var/cache/yum
 ADD cmd/csi-driver/AlmaLinux-Base.repo /etc/yum.repos.d/
 
-RUN microdnf install -y cryptsetup tar procps psmisc
+RUN microdnf install -y cryptsetup tar procps
 
 COPY --from=centos:centos7.9.2009 /usr/bin/systemctl /usr/bin/systemctl
 COPY --from=centos:7.9.2009 /usr/lib64/libgcrypt.so.11.8.2 /usr/lib64/libgcrypt.so.11.8.2
@@ -65,6 +65,7 @@ RUN ln -s /chroot/chroot-host-wrapper.sh /chroot/blkid \
     && ln -s /chroot/chroot-host-wrapper.sh /chroot/multipath \
     && ln -s /chroot/chroot-host-wrapper.sh /chroot/multipathd \
     && ln -s /chroot/chroot-host-wrapper.sh /chroot/umount \
+    && ln -s /chroot/chroot-host-wrapper.sh /chroot/fuser \
     && ln -s /chroot/chroot-host-wrapper.sh /chroot/ip \
     && ln -s /chroot/chroot-host-wrapper.sh /chroot/dmidecode \
     && ln -s /chroot/chroot-host-wrapper.sh /chroot/dnsdomainname \

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:9.4-949.1714662671
 RUN microdnf update -y && rm -rf /var/cache/yum
 ADD cmd/csi-driver/AlmaLinux-Base.repo /etc/yum.repos.d/
 
-RUN microdnf install -y cryptsetup tar procps
+RUN microdnf install -y cryptsetup tar procps psmisc
 
 COPY --from=centos:centos7.9.2009 /usr/bin/systemctl /usr/bin/systemctl
 COPY --from=centos:7.9.2009 /usr/lib64/libgcrypt.so.11.8.2 /usr/lib64/libgcrypt.so.11.8.2
@@ -30,14 +30,14 @@ COPY --from=centos:7.9.2009 /usr/lib64/libgcrypt.so.11.8.2 /usr/lib64/libgcrypt.
 RUN ln -s /usr/lib64/libgcrypt.so.11.8.2 /usr/lib64/libgcrypt.so.11
 
 LABEL name="HPE CSI Driver for Kubernetes" \
-      maintainer="HPE Storage" \
-      vendor="HPE" \
-      version="2.5.0-beta" \
-      summary="HPE CSI Driver for Kubernetes" \
-      description="The HPE CSI Driver for Kubernetes enables container orchestrators, such as Kubernetes and OpenShift, to manage the life-cycle of persistent storage." \
-      io.k8s.display-name="HPE CSI Driver for Kubernetes" \
-      io.k8s.description="The HPE CSI Driver for Kubernetes enables container orchestrators, such as Kubernetes and OpenShift, to manage the life-cycle of persistent storage." \
-      io.openshift.tags=hpe,csi,hpe-csi-driver
+    maintainer="HPE Storage" \
+    vendor="HPE" \
+    version="2.5.0-beta" \
+    summary="HPE CSI Driver for Kubernetes" \
+    description="The HPE CSI Driver for Kubernetes enables container orchestrators, such as Kubernetes and OpenShift, to manage the life-cycle of persistent storage." \
+    io.k8s.display-name="HPE CSI Driver for Kubernetes" \
+    io.k8s.description="The HPE CSI Driver for Kubernetes enables container orchestrators, such as Kubernetes and OpenShift, to manage the life-cycle of persistent storage." \
+    io.openshift.tags=hpe,csi,hpe-csi-driver
 
 WORKDIR /root
 COPY LICENSE /licenses/

--- a/cmd/csi-driver/csi-driver.go
+++ b/cmd/csi-driver/csi-driver.go
@@ -162,9 +162,17 @@ func csiCliHandler(cmd *cobra.Command) error {
 		return fmt.Errorf("invalid interval %s provided for monitoring pods on unreachable nodes", podMonitorInterval)
 	}
 
-	nmInterval, err := strconv.ParseInt(nodeMonitorInterval, 10, 64)
-	if err != nil {
-		return fmt.Errorf("invalid interval %s provided for monitoring the node", nmInterval)
+	var nmInterval int64
+	disableNodeMonitor := os.Getenv("DISABLE_NODE_MONITOR")
+	if disableNodeMonitor == "true" {
+		log.Infof("Node monitor is disabled, DISABLE_NODE_MONITOR=%v."+
+			"Skipping the node monitor", disableNodeMonitor)
+		nodeMonitor = false
+	} else {
+		nmInterval, err = strconv.ParseInt(nodeMonitorInterval, 10, 64)
+		if err != nil {
+			return fmt.Errorf("invalid interval %s provided for monitoring the node", nmInterval)
+		}
 	}
 
 	pid := os.Getpid()

--- a/cmd/csi-driver/csi-driver.go
+++ b/cmd/csi-driver/csi-driver.go
@@ -125,7 +125,7 @@ func csiCliHandler(cmd *cobra.Command) error {
 	}
 
 	if nodeInit {
-		nodeInitContainer := nodeinit.NewNodeInitContainer(flavorName, nodeService)
+		nodeInitContainer := nodeinit.NewNodeInitContainer(flavorName)
 		err := nodeInitContainer.NodeInit()
 		if err != nil {
 			log.Errorf("Error while running the init container logic: %s", err.Error())

--- a/pkg/flavor/kubernetes/flavor.go
+++ b/pkg/flavor/kubernetes/flavor.go
@@ -358,8 +358,8 @@ func (flavor *Flavor) GetNodeInfo(nodeID string) (*model.Node, error) {
 	return nil, fmt.Errorf("failed to get node with id %s", nodeID)
 }
 
-//NewClaimController provides a controller that watches for PersistentVolumeClaims and takes action on them
-//nolint: dupl
+// NewClaimController provides a controller that watches for PersistentVolumeClaims and takes action on them
+// nolint: dupl
 func (flavor *Flavor) newClaimIndexer() cache.Indexer {
 	claimListWatch := &cache.ListWatch{
 		ListFunc:  flavor.listAllClaims,
@@ -378,8 +378,8 @@ func (flavor *Flavor) newClaimIndexer() cache.Indexer {
 	return informer.GetIndexer()
 }
 
-//newSnapshotIndexer provides a controller that watches for VolumeSnapshots and takes action on them
-//nolint: dupl
+// newSnapshotIndexer provides a controller that watches for VolumeSnapshots and takes action on them
+// nolint: dupl
 func (flavor *Flavor) newSnapshotIndexer() cache.Indexer {
 	snapshotListWatch := &cache.ListWatch{
 		ListFunc:  flavor.listAllSnapshots,
@@ -806,6 +806,25 @@ func (flavor *Flavor) DeleteVolumeAttachment(va string, force bool) error {
 		return err
 	}
 	return nil
+}
+
+func (flavor *Flavor) CheckConnection() bool {
+	log.Tracef(">>>>> CheckConnection")
+	defer log.Trace("<<<<< CheckConnection")
+	return checkConnection(flavor.kubeClient)
+}
+
+func checkConnection(clientset kubernetes.Interface) bool {
+	log.Tracef(">>>>> checkConnection %+v", clientset)
+	defer log.Trace("<<<<< checkConnection")
+	_, err := clientset.CoreV1().Nodes().List(context.TODO(), meta_v1.ListOptions{})
+	if err != nil {
+		log.Errorf("Error connecting to the API server: %s\n", err.Error())
+	} else {
+		log.Infof("Successfully connected to the API server")
+		return true
+	}
+	return false
 }
 
 // MonitorPod monitors pods with given labels for being in unknown state(node unreachable/lost) and assist them to move to different node

--- a/pkg/flavor/kubernetes/flavor.go
+++ b/pkg/flavor/kubernetes/flavor.go
@@ -809,19 +809,15 @@ func (flavor *Flavor) DeleteVolumeAttachment(va string, force bool) error {
 }
 
 func (flavor *Flavor) CheckConnection() bool {
-	log.Tracef(">>>>> CheckConnection")
-	defer log.Trace("<<<<< CheckConnection")
 	return checkConnection(flavor.kubeClient)
 }
 
 func checkConnection(clientset kubernetes.Interface) bool {
-	log.Tracef(">>>>> checkConnection %+v", clientset)
-	defer log.Trace("<<<<< checkConnection")
 	_, err := clientset.CoreV1().Nodes().List(context.TODO(), meta_v1.ListOptions{})
 	if err != nil {
 		log.Errorf("Error connecting to the API server: %s\n", err.Error())
 	} else {
-		log.Infof("Successfully connected to the API server")
+		log.Tracef("Successfully connected to the API server")
 		return true
 	}
 	return false

--- a/pkg/flavor/types.go
+++ b/pkg/flavor/types.go
@@ -41,4 +41,5 @@ type Flavor interface {
 	GetGroupSnapshotNameFromSnapshotName(snapshotName string) (string, error)
 	ListVolumeAttachments() (*storage_v1.VolumeAttachmentList, error)
 	GetChapCredentialsFromVolumeContext(volumeContext map[string]string) (map[string]string, error)
+	CheckConnection() bool
 }

--- a/pkg/flavor/vanilla/flavor.go
+++ b/pkg/flavor/vanilla/flavor.go
@@ -116,3 +116,7 @@ func (flavor *Flavor) GetChapCredentialsFromVolumeContext(volumeContext map[stri
 func (flavor *Flavor) ListVolumeAttachments() (*storage_v1.VolumeAttachmentList, error) {
 	return nil, nil
 }
+
+func (flavor *Flavor) CheckConnection() bool {
+	return false
+}

--- a/pkg/nodeinit/nodeinit.go
+++ b/pkg/nodeinit/nodeinit.go
@@ -17,7 +17,7 @@ type NodeInitContainer struct {
 func NewNodeInitContainer(flavorName string) *NodeInitContainer {
 	var nodeInitFlavour flavor.Flavor
 	if flavorName == flavor.Kubernetes {
-		flavor, err := kubernetes.NewKubernetesFlavor(false, nil)
+		flavor, err := kubernetes.NewKubernetesFlavor(true, nil)
 		if err != nil {
 			return nil
 		}

--- a/pkg/nodeinit/nodeinit.go
+++ b/pkg/nodeinit/nodeinit.go
@@ -14,10 +14,10 @@ type NodeInitContainer struct {
 	nodeName string
 }
 
-func NewNodeInitContainer(flavorName string, nodeService bool) *NodeInitContainer {
+func NewNodeInitContainer(flavorName string) *NodeInitContainer {
 	var nodeInitFlavour flavor.Flavor
 	if flavorName == flavor.Kubernetes {
-		flavor, err := kubernetes.NewKubernetesFlavor(nodeService, nil)
+		flavor, err := kubernetes.NewKubernetesFlavor(false, nil)
 		if err != nil {
 			return nil
 		}

--- a/pkg/nodeinit/nodeinit.go
+++ b/pkg/nodeinit/nodeinit.go
@@ -30,7 +30,6 @@ func NewNodeInitContainer(flavorName string, nodeService bool) *NodeInitContaine
 		nic.nodeName = key
 	}
 	log.Debugf("NodeInitContainer: %+v", nic)
-	// initialize NodeInitContainer
 	return nic
 }
 

--- a/pkg/nodeinit/utils.go
+++ b/pkg/nodeinit/utils.go
@@ -143,6 +143,13 @@ func cleanup(device *model.MultipathDevice) error {
 		log.Errorf("Unable to unmount the multipath device's references%s: %s", device.Name, err.Error())
 		return err
 	}
+
+	log.Infof("Killing the processes using the device %s if any", device.Name)
+	err = tunelinux.killProcessesUisngMountPoints("/dev/mapper/" + device.Name)
+	if err != nil {
+		log.Errorf("Unable to kill the processes using the device %s: %s", device.Name, err.Error())
+		return err
+	}
 	//remove block devices of multipath device
 	err = tunelinux.RemoveBlockDevicesOfMultipathDevices(*device)
 	if err != nil {

--- a/pkg/nodeinit/utils.go
+++ b/pkg/nodeinit/utils.go
@@ -145,7 +145,7 @@ func cleanup(device *model.MultipathDevice) error {
 	}
 
 	log.Infof("Killing the processes using the device %s if any", device.Name)
-	err = tunelinux.killProcessesUisngMountPoints("/dev/mapper/" + device.Name)
+	err = tunelinux.KillProcessesUisngMountPoints("/dev/mapper/" + device.Name)
 	if err != nil {
 		log.Errorf("Unable to kill the processes using the device %s: %s", device.Name, err.Error())
 		return err

--- a/pkg/nodeinit/utils.go
+++ b/pkg/nodeinit/utils.go
@@ -1,13 +1,13 @@
 package nodeinit
 
 import (
+	"os"
+
 	log "github.com/hpe-storage/common-host-libs/logger"
 	"github.com/hpe-storage/common-host-libs/model"
 	"github.com/hpe-storage/common-host-libs/tunelinux"
 	"github.com/hpe-storage/csi-driver/pkg/flavor"
 	storage_v1 "k8s.io/api/storage/v1"
-
-	"os"
 )
 
 func doesDeviceBelongToTheNode(multipathDevice *model.MultipathDevice, volumeAttachmentList *storage_v1.VolumeAttachmentList, nodeName string) bool {
@@ -33,7 +33,7 @@ func AnalyzeMultiPathDevices(flavor flavor.Flavor, nodeName string) error {
 	disableNodeMonitor := os.Getenv("DISABLE_NODE_MONITOR")
 	if disableNodeMonitor == "true" {
 		log.Infof("Node monitor is disabled, DISABLE_NODE_MONITOR=%v."+
-			"Skipping the node monitor", disableNodeMonitor)
+			"Skipping the cleanup of stale multipath devices", disableNodeMonitor)
 		disableCleanup = true
 	}
 

--- a/pkg/nodeinit/utils.go
+++ b/pkg/nodeinit/utils.go
@@ -67,6 +67,9 @@ func AnalyzeMultiPathDevices(flavor flavor.Flavor, nodeName string) error {
 			if err_count > 0 {
 				log.Infof("Failed to remove %d multipath devices on the node %s", err_count, nodeName)
 				return err
+			} else {
+				//No error while cleaninup or no devices are there to clean
+				return nil
 			}
 		} else {
 			log.Tracef("No multipath devices found on the node %s", nodeName)
@@ -161,5 +164,6 @@ func cleanup(device *model.MultipathDevice) error {
 		log.Errorf("Unable to flush the multipath device %s: %s", device.Name, err.Error())
 		return err
 	}
+	log.Infof("The multipath device %s is removed successfully", device.Name)
 	return nil
 }

--- a/pkg/nodeinit/utils.go
+++ b/pkg/nodeinit/utils.go
@@ -145,7 +145,7 @@ func cleanup(device *model.MultipathDevice) error {
 	log.Tracef(">>>>> Cleaning up the multipath device %s", device.Name)
 	defer log.Trace("<<<<< cleanup")
 
-	err := tunelinux.KillProcessesUsingMountPoints(device.Name)
+	err := tunelinux.KillProcessesUsingMountPoints("/dev/mapper/" + device.Name)
 	if err != nil {
 		log.Errorf("Unable to kill the processes using the multipath device's references %s: %s", device.Name, err.Error())
 		return err

--- a/pkg/nodeinit/utils.go
+++ b/pkg/nodeinit/utils.go
@@ -44,7 +44,7 @@ func AnalyzeMultiPathDevices(flavor flavor.Flavor, nodeName string) error {
 
 	log.Tracef("Checking the connection to control plane....")
 	if !flavor.CheckConnection() {
-		log.Infof("Node %s is unable to connect to the control plane.", nodeName)
+		log.Infof("The node %s is unable to connect to the control plane.", nodeName)
 		if multipathDevices != nil && len(multipathDevices) > 0 {
 			for _, device := range multipathDevices {
 				log.Tracef("Name:%s Vendor:%s Paths:%f Path Faults:%f UUID:%s IsUnhealthy:%t", device.Name, device.Vend, device.Paths, device.PathFaults, device.UUID, device.IsUnhealthy)
@@ -68,7 +68,7 @@ func AnalyzeMultiPathDevices(flavor flavor.Flavor, nodeName string) error {
 			return nil
 		}
 	} else {
-		log.Infof("Node %s has proper connection with control plane", nodeName)
+		log.Infof("Node %s has a proper connection with the control plane", nodeName)
 	}
 
 	vaList, err := flavor.ListVolumeAttachments()
@@ -108,7 +108,7 @@ func AnalyzeMultiPathDevices(flavor flavor.Flavor, nodeName string) error {
 			}
 		} else {
 			if device.IsUnhealthy {
-				log.Infof("No volume attachments found. The multipath device is unhealthy and does not belong to the hpe csi driver, do cleanup!")
+				log.Infof("No volume attachments found. The multipath device is unhealthy and does not belong to the hpe csi driver, do clean up!")
 				// Do cleanup
 				if !disableCleanup {
 					err = cleanup(&device)
@@ -140,7 +140,7 @@ func cleanup(device *model.MultipathDevice) error {
 	//unmount references & kill processes explicitly, if umount fails
 	err := tunelinux.UnmountMultipathDevice(device.Name)
 	if err != nil {
-		log.Errorf("Unable to unmount the multipath device's references%s: %s", device.Name, err.Error())
+		log.Errorf("Unable to unmount the multipath device's references %s: %s", device.Name, err.Error())
 		return err
 	}
 

--- a/pkg/nodeinit/utils.go
+++ b/pkg/nodeinit/utils.go
@@ -50,7 +50,6 @@ func AnalyzeMultiPathDevices(flavor flavor.Flavor, nodeName string) error {
 				log.Tracef("Name:%s Vendor:%s Paths:%f Path Faults:%f UUID:%s IsUnhealthy:%t", device.Name, device.Vend, device.Paths, device.PathFaults, device.UUID, device.IsUnhealthy)
 				if device.IsUnhealthy {
 					log.Infof("Multipath device %s on the node %s is unhealthy", device.Name, nodeName)
-					log.Infof("Cleaning the stale multipath device %s as the DISABLE_CLEANUP is set", device.Name)
 					err = cleanup(&device)
 					if err != nil {
 						log.Errorf("Unable to cleanup the multipath device %s: %s", device.Name, err.Error())
@@ -87,9 +86,9 @@ func AnalyzeMultiPathDevices(flavor flavor.Flavor, nodeName string) error {
 			if doesDeviceBelongToTheNode(&device, vaList, nodeName) {
 				log.Infof("Multipath device %s belongs to the node %s", device.Name, nodeName)
 				if device.IsUnhealthy {
-					log.Infof("The multipath device %s belongs to this node %s and is unhealthy. Issue warnings!", device.Name, nodeName)
+					log.Infof("The multipath device %s belongs to this node %s and is unhealthy.", device.Name, nodeName)
 				} else {
-					log.Infof("The multipath device %s belongs to this node %s and is healthy. Nothing to do", device.Name, nodeName)
+					log.Infof("The multipath device %s belongs to this node %s and is healthy.", device.Name, nodeName)
 				}
 			} else {
 				log.Infof("Multipath device %s does not not belong to the node %s", device.Name, nodeName)
@@ -106,7 +105,7 @@ func AnalyzeMultiPathDevices(flavor flavor.Flavor, nodeName string) error {
 						log.Warnf("Skipping the removal of stale multipath device %s as the DISABLE_NODE_MONITOR is set to %s", device.Name, disableNodeMonitor)
 					}
 				} else {
-					log.Infof("The multipath device %s is healthy and it does not belong to the node %s. Issue warnings!", device.Name, nodeName)
+					log.Infof("The multipath device %s is healthy and it does not belong to the node %s.", device.Name, nodeName)
 				}
 			}
 		} else {

--- a/pkg/nodeinit/utils.go
+++ b/pkg/nodeinit/utils.go
@@ -144,12 +144,6 @@ func cleanup(device *model.MultipathDevice) error {
 		return err
 	}
 
-	log.Infof("Killing the processes using the device %s if any", device.Name)
-	err = tunelinux.KillProcessesUisngMountPoints("/dev/mapper/" + device.Name)
-	if err != nil {
-		log.Errorf("Unable to kill the processes using the device %s: %s", device.Name, err.Error())
-		return err
-	}
 	//remove block devices of multipath device
 	err = tunelinux.RemoveBlockDevicesOfMultipathDevices(*device)
 	if err != nil {

--- a/pkg/nodeinit/utils.go
+++ b/pkg/nodeinit/utils.go
@@ -54,7 +54,7 @@ func AnalyzeMultiPathDevices(flavor flavor.Flavor, nodeName string) error {
 				if device.IsUnhealthy {
 					log.Infof("Multipath device %s on the node %s is unhealthy", device.Name, nodeName)
 					log.Infof("Cleaning the stale multipath device %s as the DISABLE_CLEANUP is set", device.Name)
-					err = cleanup(device)
+					err = cleanup(&device)
 					if err != nil {
 						log.Errorf("Unable to cleanup the multipath device %s: %s", device.Name, err.Error())
 						err_count = err_count + 1
@@ -87,7 +87,7 @@ func AnalyzeMultiPathDevices(flavor flavor.Flavor, nodeName string) error {
 	for _, device := range multipathDevices {
 		if vaList != nil && len(vaList.Items) > 0 {
 			log.Infof("Assessing the multipath device %s", device.Name)
-			if doesDeviceBelongToTheNode(device, vaList, nodeName) {
+			if doesDeviceBelongToTheNode(&device, vaList, nodeName) {
 				log.Infof("Multipath device %s belongs to the node %s", device.Name, nodeName)
 				if device.IsUnhealthy {
 					log.Infof("The multipath device %s belongs to this node %s and is unhealthy. Issue warnings!", device.Name, nodeName)
@@ -101,7 +101,7 @@ func AnalyzeMultiPathDevices(flavor flavor.Flavor, nodeName string) error {
 					//do cleanup
 					if !disableCleanup {
 						log.Infof("Cleaning the stale multipath device %s as the DISABLE_NODE_MONITOR is set", device.Name)
-						err = cleanup(device)
+						err = cleanup(&device)
 						if err != nil {
 							log.Errorf("Unable to cleanup the multipath device %s", device.Name)
 							err_count = err_count + 1
@@ -119,7 +119,7 @@ func AnalyzeMultiPathDevices(flavor flavor.Flavor, nodeName string) error {
 				// Do cleanup
 				if !disableCleanup {
 					log.Infof("Cleaning the stale multipath device %s as the DISABLE_CLEANUP is set", device.Name)
-					err = cleanup(device)
+					err = cleanup(&device)
 					if err != nil {
 						log.Errorf("Unable to cleanup the multipath device %s", device.Name)
 						err_count = err_count + 1

--- a/pkg/nodeinit/utils.go
+++ b/pkg/nodeinit/utils.go
@@ -43,6 +43,7 @@ func AnalyzeMultiPathDevices(flavor flavor.Flavor, nodeName string) error {
 		log.Errorf("Error while getting the information of multipath devices on the node %s", nodeName)
 		return err
 	}
+	log.Infof(" %d multipath devices found on the node %s", len(multipathDevices), nodeName)
 
 	log.Infof("Checking the connection to control plane....")
 	if !flavor.CheckConnection() {
@@ -77,6 +78,10 @@ func AnalyzeMultiPathDevices(flavor flavor.Flavor, nodeName string) error {
 	vaList, err := flavor.ListVolumeAttachments()
 	if err != nil {
 		return err
+	}
+
+	if vaList != nil {
+		log.Infof("%d volume attachments found", len(vaList.Items))
 	}
 
 	for _, device := range multipathDevices {

--- a/pkg/nodeinit/utils.go
+++ b/pkg/nodeinit/utils.go
@@ -40,8 +40,13 @@ func AnalyzeMultiPathDevices(flavor flavor.Flavor, nodeName string) error {
 		log.Errorf("Error while getting the information of multipath devices on the node %s", nodeName)
 		return err
 	}
-	log.Infof(" %d multipath devices found on the node %s", len(multipathDevices), nodeName)
 
+	if len(multipathDevices) == 0 {
+		log.Infof("No multipath devices found on this node %s.", nodeName)
+		return nil
+	}
+
+	log.Infof(" %d multipath devices found on the node %s", len(multipathDevices), nodeName)
 	log.Tracef("Checking the connection to control plane....")
 	if !flavor.CheckConnection() {
 		log.Infof("The node %s is unable to connect to the control plane.", nodeName)

--- a/pkg/nodeinit/utils.go
+++ b/pkg/nodeinit/utils.go
@@ -84,16 +84,14 @@ func AnalyzeMultiPathDevices(flavor flavor.Flavor, nodeName string) error {
 		if vaList != nil && len(vaList.Items) > 0 {
 			log.Infof("Assessing the multipath device %s", device.Name)
 			if doesDeviceBelongToTheNode(&device, vaList, nodeName) {
-				log.Infof("Multipath device %s belongs to the node %s", device.Name, nodeName)
 				if device.IsUnhealthy {
 					log.Infof("The multipath device %s belongs to this node %s and is unhealthy.", device.Name, nodeName)
 				} else {
 					log.Infof("The multipath device %s belongs to this node %s and is healthy.", device.Name, nodeName)
 				}
 			} else {
-				log.Infof("Multipath device %s does not not belong to the node %s", device.Name, nodeName)
 				if device.IsUnhealthy {
-					log.Infof("The multipath device %s is unhealthy and it does not belong to the node %s", device.Name, nodeName)
+					log.Infof("The multipath device %s is unhealthy and either it does not belong to the node %s or is not created by the hpe csi driver.", device.Name, nodeName)
 					//do cleanup
 					if !disableCleanup {
 						err = cleanup(&device)
@@ -105,7 +103,7 @@ func AnalyzeMultiPathDevices(flavor flavor.Flavor, nodeName string) error {
 						log.Warnf("Skipping the removal of stale multipath device %s as the DISABLE_NODE_MONITOR is set to %s", device.Name, disableNodeMonitor)
 					}
 				} else {
-					log.Infof("The multipath device %s is healthy and it does not belong to the node %s.", device.Name, nodeName)
+					log.Infof("The multipath device %s is healthy and either it does not belong to the node %s or is not created by the hpe csi driver.", device.Name, nodeName)
 				}
 			}
 		} else {

--- a/pkg/nodemonitor/nodemonitor.go
+++ b/pkg/nodemonitor/nodemonitor.go
@@ -23,8 +23,7 @@ func NewNodeMonitor(flavor flavor.Flavor, monitorInterval int64) *NodeMonitor {
 	if key := os.Getenv("NODE_NAME"); key != "" {
 		nm.nodeName = key
 	}
-	log.Infof("NODE MONITOR: %+v", nm)
-	// initialize node monitor
+	log.Tracef("NODE MONITOR: %+v", nm)
 	return nm
 }
 
@@ -54,7 +53,7 @@ func (nm *NodeMonitor) StartNodeMonitor() error {
 	if nm.intervalSec == 0 {
 		nm.intervalSec = defaultIntervalSec
 	} else if nm.intervalSec < minimumIntervalSec {
-		log.Warnf("minimum interval for health monitor is %v seconds", minimumIntervalSec)
+		log.Warnf("minimum interval for node monitor is %v seconds", minimumIntervalSec)
 		nm.intervalSec = minimumIntervalSec
 	}
 

--- a/pkg/nodemonitor/nodemonitor.go
+++ b/pkg/nodemonitor/nodemonitor.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	defaultIntervalSec = 30
+	defaultIntervalSec = 60
 	minimumIntervalSec = 15
 )
 

--- a/pkg/nodemonitor/nodemonitor.go
+++ b/pkg/nodemonitor/nodemonitor.go
@@ -103,7 +103,6 @@ func (nm *NodeMonitor) monitorNode() error {
 				err := nodeinit.AnalyzeMultiPathDevices(nm.flavor, nm.nodeName)
 				if err != nil {
 					log.Errorf("Error while analyzing the multipath devices %s on the node %s", err.Error(), nm.nodeName)
-					return
 				}
 			case <-nm.stopChannel:
 				return


### PR DESCRIPTION
The following functionalities are implemented in phase 3:

1. Unmount all references to the device, bind mounts, and real mounts.
2. Kill processes using the mount points and devices
3. Remove block devices
4. Flush the multipath map
5. Enable and disable of node monitor and cleanup in the node init container based on the user's choice

made improvements for the previous  phase's implementation as well