### PR TITLE
Fixes CON-3120

### DIFF
--- a/pkg/driver/constants.go
+++ b/pkg/driver/constants.go
@@ -50,7 +50,6 @@ const (
 
 	discoveryIPsKey       = "discoveryIps"
 	readOnlyKey           = "readOnly"
-	volumeAccessModeKey   = "volumeAccessMode"
 	multiInitiatorKey     = "multiInitiator"
 	defaultConnectionMode = "manual"
 	KubeletRootDirEnvKey  = "KUBELET_ROOT_DIR"


### PR DESCRIPTION
- Passes CSI e2e testing on Nimble and 3PAR
- Passes k10primer on Nimble and 3PAR
- Passes kubevirt-storage-checkup on 3PAR