### PR TITLE
CON-3170:Fix the failures seen in CSI Sanity unit-test case execution

### DIFF
--- a/pkg/driver/node_server.go
+++ b/pkg/driver/node_server.go
@@ -2000,9 +2000,9 @@ func (driver *Driver) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoReque
 	}
 
 	topo := &csi.Topology{Segments: accessableTopologySegments}
-	if len(accessableTopologySegments) == 0 {
-		topo = nil
-	}
+	// if len(accessableTopologySegments) == 0 {
+	// 	topo = nil
+	// }
 
 	log.Infof("node %s topo: %+v", nodeInfo.Name, topo)
 	// Get max volume per node from environment variable


### PR DESCRIPTION
After running multiple test cases, I came to the conclusion that rewriting the old Segments map would have the same effect as commenting out those lines and hence I commented out those lines