### PR TITLE
CON-3153 Support for Unified File in R5

### DIFF
--- a/pkg/driver/controller_server.go
+++ b/pkg/driver/controller_server.go
@@ -304,9 +304,13 @@ func (driver *Driver) createVolume(
 			filesystem = defaultFileSystem
 			log.Trace("Using default filesystem type: ", filesystem)
 		}
-		if driver.IsSupportedMultiNodeAccessMode(volumeCapabilities) && !driver.IsNFSResourceRequest(createParameters) {
-			return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("StorageClass parameter %s=%s is missing for creation of volumes with multi-node access", nfsResourcesKey, trueKey))
+		if driver.IsSupportedMultiNodeAccessMode(volumeCapabilities) && !(driver.IsNFSResourceRequest(createParameters) || driver.IsFileRequest(createParameters)) {
+			return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("StorageClass parameter %s=%s is missing for creation of volumes with multi-node access for NFS or  StorageClass parameter %s=%s is missing for creation of volumes with multi-node access File", nfsResourcesKey, trueKey, accessProtocolKey, nfsFileSystem))
 		}
+	}
+
+	if volAccessType == model.BlockType && driver.IsFileRequest(createParameters) {
+		return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("volume mode can't be block for File"))
 	}
 
 	// Verify if NFS based provisioning is requested
@@ -815,6 +819,27 @@ func (driver *Driver) controllerPublishVolume(
 		}, nil
 	}
 
+	if driver.IsFileRequest(volumeContext) {
+		// Get storageProvider using secrets
+		storageProvider, err := driver.GetStorageProvider(secrets)
+		if err != nil {
+			log.Error("err: ", err.Error())
+			return nil, status.Error(codes.Unavailable,
+				fmt.Sprintf("Failed to get storage provider from secrets, err: %s", err.Error()))
+		}
+		_, err = storageProvider.PublishVolume(volumeID, nodeID, volumeContext[accessProtocolKey])
+		if err != nil {
+			log.Errorf("Failed to publish volume %s, err: %s", volumeID, err.Error())
+			return nil, status.Error(codes.Internal,
+				fmt.Sprintf("Failed to add file share settings access for volume %s for node %s via File CSP, err: %s", volumeID, nodeID, err.Error()))
+		}
+		log.Info("ControllerPublish requested with file resources, returning success")
+		return map[string]string{
+			readOnlyKey:        strconv.FormatBool(readOnlyAccessMode),
+			nfsMountOptionsKey: volumeContext[nfsMountOptionsKey],
+		}, nil
+	}
+
 	// Get Volume using secrets
 	volume, err := driver.GetVolumeByID(volumeID, secrets)
 	if err != nil {
@@ -1030,6 +1055,11 @@ func (driver *Driver) controllerUnpublishVolume(volumeID string, nodeID string, 
 		}
 		log.Errorf("Failed to get volume %s, err: %s", volumeID, err.Error())
 		return err
+	}
+
+	if existingVolume.AccessProtocol == nfsFileSystem {
+		log.Info("ControllerUnpublish requested for File with multi-node access-mode, returning success")
+		return nil
 	}
 
 	// pass the nodeID to the container storage provider and do not do a look up of the node object as
@@ -1555,53 +1585,51 @@ func (driver *Driver) ControllerExpandVolume(ctx context.Context, request *csi.C
 
 	// TODO: Add info to DB
 
+	// Get Volume
+	existingVolume, err := driver.GetVolumeByID(request.VolumeId, request.Secrets)
+	if err != nil && strings.Contains(request.VolumeId, "pvc-") {
+		log.Error("Failed to get volume with ID ", request.VolumeId)
+		return nil, err
+	}
+	if existingVolume != nil {
+		log.Tracef("Found Volume %s with ID %s", existingVolume.Name, existingVolume.ID)
+	}
+
 	//Handling NFS PVC request
-	if !strings.Contains(request.VolumeId, "pvc-") {
+	if !strings.Contains(request.VolumeId, "pvc-") && err != nil {
 		// Regular Nimble volumes will have the volume Id will be like this '06189263bcc823a018000000000000000000000087'
 		// But for NFS Nimble Volumes, the volume Id will be like this 634bdb9e-158a-4fb8-90fb-78eb1bad0bba
 		// This check is to prevent the processing of regular Nimble volumes
 		log.Tracef("Found a foreign UUID for the volume %s, check if it is Nimble Volume or not", request.VolumeId)
-		_, err := driver.GetVolumeByID(request.VolumeId, request.Secrets)
+		nfsVolumeID, err := driver.flavor.GetNFSVolumeID(request.VolumeId)
 		if err != nil {
-			log.Tracef("Failed to get volume with ID %s. Check whether it is NFS volume or not", request.VolumeId)
-			nfsVolumeID, err := driver.flavor.GetNFSVolumeID(request.VolumeId)
+			return nil, status.Error(codes.Internal, fmt.Sprintf("Failed to get the volume details for the foreign UUID %s: %s", request.VolumeId, err.Error()))
+		}
+		corrected_volumeId := "pvc-" + request.VolumeId
+		log.Infof("Found the RWO volume %s associated with the NFS volume %s", nfsVolumeID, corrected_volumeId)
+		if !strings.Contains(nfsVolumeID, "pvc-") {
+			log.Tracef("This backend RWO volume is a Nimble Volume, %s, lets find the appropriate pv name", nfsVolumeID)
+			existingVolume, err := driver.GetVolumeByID(nfsVolumeID, request.Secrets)
 			if err != nil {
-				return nil, status.Error(codes.Internal, fmt.Sprintf("Failed to get the volume details for the foreign UUID %s: %s", request.VolumeId, err.Error()))
-			}
-			corrected_volumeId := "pvc-" + request.VolumeId
-			log.Infof("Found the RWO volume %s associated with the NFS volume %s", nfsVolumeID, corrected_volumeId)
-			if !strings.Contains(nfsVolumeID, "pvc-") {
-				log.Tracef("This backend RWO volume is a Nimble Volume, %s, lets find the appropriate pv name", nfsVolumeID)
-				existingVolume, err := driver.GetVolumeByID(nfsVolumeID, request.Secrets)
-				if err != nil {
-					log.Error("Failed to get Nimble volume with ID ", request.VolumeId)
-					return nil, err
-				}
-				log.Tracef("Found Nimble backend RWO Volume %s with ID %s", existingVolume.Name, existingVolume.ID)
-				nfsVolumeID = existingVolume.Name
-			}
-
-			err = driver.flavor.ExpandNFSBackendVolume(nfsVolumeID, request.CapacityRange.GetRequiredBytes())
-			if err != nil {
-				log.Errorf("Failed to update the backend RWO volume of NFS volume %s: %s", corrected_volumeId, err.Error())
+				log.Error("Failed to get Nimble volume with ID ", request.VolumeId)
 				return nil, err
 			}
-			log.Infof("The size of the backend RWO volume %s associated with the NFS volume %s has been updated", nfsVolumeID, corrected_volumeId)
-			//NFS client will take care of resizing
-			return &csi.ControllerExpandVolumeResponse{
-				CapacityBytes:         request.CapacityRange.GetRequiredBytes(),
-				NodeExpansionRequired: false,
-			}, nil
-		} // If this fails, then the request with foreign uid may belong to Nimlble.
-	}
+			log.Tracef("Found Nimble backend RWO Volume %s with ID %s", existingVolume.Name, existingVolume.ID)
+			nfsVolumeID = existingVolume.Name
+		}
 
-	// Get Volume
-	existingVolume, err := driver.GetVolumeByID(request.VolumeId, request.Secrets)
-	if err != nil {
-		log.Error("Failed to get volume with ID ", request.VolumeId)
-		return nil, err
+		err = driver.flavor.ExpandNFSBackendVolume(nfsVolumeID, request.CapacityRange.GetRequiredBytes())
+		if err != nil {
+			log.Errorf("Failed to update the backend RWO volume of NFS volume %s: %s", corrected_volumeId, err.Error())
+			return nil, err
+		}
+		log.Infof("The size of the backend RWO volume %s associated with the NFS volume %s has been updated", nfsVolumeID, corrected_volumeId)
+		//NFS client will take care of resizing
+		return &csi.ControllerExpandVolumeResponse{
+			CapacityBytes:         request.CapacityRange.GetRequiredBytes(),
+			NodeExpansionRequired: false,
+		}, nil
 	}
-	log.Tracef("Found Volume %s with ID %s", existingVolume.Name, existingVolume.ID)
 
 	// Set node expansion required to 'true' for mount type as fs resize is always required in that case
 	nodeExpansionRequired := true
@@ -1615,6 +1643,9 @@ func (driver *Driver) ControllerExpandVolume(ctx context.Context, request *csi.C
 		}
 	}
 
+	if existingVolume.AccessProtocol == nfsFileSystem {
+		nodeExpansionRequired = false
+	}
 	if existingVolume.Size == request.CapacityRange.GetLimitBytes() || existingVolume.Size == request.CapacityRange.GetRequiredBytes() {
 		// volume is already at requested size, so no action required.
 		log.Tracef("volume %s is already at requested size, so no action required", request.VolumeId)

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -389,7 +389,7 @@ func (driver *Driver) GetStorageProvider(secrets map[string]string) (storageprov
 
 // GenerateStorageProviderCacheKey generates unique hash for the credential pair {Backend, Username}
 func (driver *Driver) GenerateStorageProviderCacheKey(credentials *storageprovider.Credentials) string {
-	result := sha256.Sum256([]byte(fmt.Sprintf("%s%s", credentials.Backend, credentials.Username)))
+	result := sha256.Sum256([]byte(fmt.Sprintf("%s%s%s", credentials.ServiceName, credentials.Backend, credentials.Username)))
 	return fmt.Sprintf("%x", result)
 }
 
@@ -830,6 +830,11 @@ func (driver *Driver) ScrubEphemeralPods(podsDirPath string) error {
 		}
 	}
 	return nil
+}
+
+func (driver *Driver) IsFileRequest(parameters map[string]string) bool {
+	accessProtocol, ok := parameters[accessProtocolKey]
+	return ok && accessProtocol == nfsFileSystem
 }
 
 /******************************************************************************************/

--- a/pkg/driver/driver_test.go
+++ b/pkg/driver/driver_test.go
@@ -86,8 +86,9 @@ func fakeDriver(endpoint string) *Driver {
 	}
 
 	credential := &storageprovider.Credentials{
-		Username: "fake",
-		Backend:  "fake",
+		Username:    "fake",
+		Backend:     "fake",
+		ServiceName: "fake",
 	}
 	cacheKey := driver.GenerateStorageProviderCacheKey(credential)
 	driver.storageProviders[cacheKey] = fake.NewFakeStorageProvider()
@@ -131,29 +132,34 @@ func TestGenerateStorageProviderCacheKey(t *testing.T) {
 	}
 
 	cred1 := &storageprovider.Credentials{
-		Username: "admin",
-		Password: "password",
-		Backend:  "1.1.1.1",
+		Username:    "admin",
+		Password:    "password",
+		Backend:     "1.1.1.1",
+		ServiceName: "fake",
 	}
 	cred2 := &storageprovider.Credentials{
-		Username: "user",
-		Password: "password",
-		Backend:  "1.1.1.1",
+		Username:    "user",
+		Password:    "password",
+		Backend:     "1.1.1.1",
+		ServiceName: "fake",
 	}
 	cred3 := &storageprovider.Credentials{
-		Username: "test",
-		Password: "password",
-		Backend:  "1.1.1.1",
+		Username:    "test",
+		Password:    "password",
+		Backend:     "1.1.1.1",
+		ServiceName: "fake",
 	}
 	cred4 := &storageprovider.Credentials{
-		Username: "test",
-		Password: "password",
-		Backend:  "2.2.2.2",
+		Username:    "test",
+		Password:    "password",
+		Backend:     "2.2.2.2",
+		ServiceName: "fake",
 	}
 	cred5 := &storageprovider.Credentials{
-		Username: "user",
-		Password: "password",
-		Backend:  "2.2.2.2",
+		Username:    "user",
+		Password:    "password",
+		Backend:     "2.2.2.2",
+		ServiceName: "fake",
 	}
 
 	type args struct {
@@ -166,12 +172,12 @@ func TestGenerateStorageProviderCacheKey(t *testing.T) {
 		expected string
 		fails    bool
 	}{
-		{"Test for user1", args{cred1}, "6903fab9e2797c294e1c4a0b87a5f296acb887f946d471ee90d0f6caeecd42ea", false},
-		{"Test for user1", args{cred1}, "6903fab9e2797c294e1c4a0b87a5f296acb887f946d471ee90d0f6caeecd42", true},
-		{"Test for user2", args{cred2}, "7768c1adea41b7cacff35a4648d98a47372c1b14c7843712b5414092290dd26b", false},
-		{"Test for user3", args{cred3}, "eebff4d52bb48b871bf5b63b15d3deee6efb9997a067a4aac39ff0601cb41c39", false},
-		{"Test for user4", args{cred4}, "cc3302d1062f0561eddba8f91606dab0688ac676ffc8fefcc0c827b206803b81", false},
-		{"Test for user5", args{cred5}, "03fa2eb6d209f927fa680ec64275a8242c74a82d3d44aea7610fc5358732b6b5", false},
+		{"Test for user1", args{cred1}, "10ea735ee58e2a9ce159ee7d5e9439c05da47b2f91c85d4dcb5152c3295390ba", false},
+		{"Test for user1", args{cred1}, "10ea735ee58e2a9ce159ee7d5e9439c05da47b2f91c85d4dcb5152c3295390ba", true},
+		{"Test for user2", args{cred2}, "4d1207ac0389f6b9d593e3d8bdbf610e5441ca9679d85380cea9a9ea31bb2292", false},
+		{"Test for user3", args{cred3}, "5729f10afcd4e1868f2f1351861012354c9989eefd971c489f44f7c7583be4b8", false},
+		{"Test for user4", args{cred4}, "99cc4ecbf4fbe1ae762f6971752663e41a2701bc1cb3d4159a389e6ad799c984", false},
+		{"Test for user5", args{cred5}, "9b882f7526e28c59e9507b07543fcad084d52597935d92e4815d3d086237a0a4", false},
 	}
 
 	for _, tt := range tests {

--- a/pkg/driver/utils.go
+++ b/pkg/driver/utils.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"net"
 	"os"
 	"path"
 	"path/filepath"
@@ -117,4 +118,11 @@ func removeDataFile(dirPath string, fileName string) error {
 	defer log.Trace("<<<<< removeDataFile")
 	filePath := path.Join(dirPath, fileName)
 	return util.FileDelete(filePath)
+}
+
+// isValidIP checks whether the provided string is a valid IP address.
+// It returns true if the input is non-empty and can be parsed as an IP address,
+// otherwise it returns false.
+func isValidIP(ip string) bool {
+	return ip != "" && net.ParseIP(ip) != nil
 }

--- a/pkg/flavor/kubernetes/file.go
+++ b/pkg/flavor/kubernetes/file.go
@@ -1,0 +1,79 @@
+// Copyright 2025 Hewlett Packard Enterprise Development LP
+package kubernetes
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	log "github.com/hpe-storage/common-host-libs/logger"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+const (
+	NFS              = "nfs"
+	shareNfsVersion  = "shareNfsVersion"
+	fileHostIPKey    = "hostIP"
+	fileMountPathKey = "mountPath"
+)
+
+// HandleFileNodePublish handles the NodePublishVolume request for file-based volumes in a Kubernetes environment.
+// It ensures that the volume is properly mounted to the target path using NFS.
+//
+// Parameters:
+// - req: The NodePublishVolumeRequest containing volume details, target path, and context.
+//
+// Steps:
+// 1. Extracts the cluster IP and export path from the volume context.
+// 2. Validates that the cluster IP and export path are not empty.
+// 3. Constructs the NFS source and target path.
+// 4. Retrieves or sets default NFS mount options.
+// 5. Creates the target directory if it does not exist.
+// 6. Mounts the NFS volume to the target path.
+//
+// Returns:
+// - A NodePublishVolumeResponse on successful mount.
+// - An error if any step in the process fails.
+
+func (flavor *Flavor) HandleFileNodePublish(req *csi.NodePublishVolumeRequest) (*csi.NodePublishVolumeResponse, error) {
+	log.Tracef(">>>>> HandleFileNodePublish with volume %s target path %s", req.VolumeId, req.TargetPath)
+	defer log.Tracef("<<<<< HandleFileNodePublish")
+	var mountOptions []string
+	var clusterIP, exportPath string
+	var existHostIP, existExportPath bool
+	clusterIP, existHostIP = req.VolumeContext[fileHostIPKey]
+	exportPath, existExportPath = req.VolumeContext[fileMountPathKey]
+	if !existHostIP || !existExportPath {
+		errStr := fmt.Sprintf("failed to create file provisioned volume with hostip: %s, and mount path: %s, host ip or mount path should not be empty ", clusterIP, exportPath)
+		log.Errorf(errStr)
+		return nil, status.Error(codes.Internal, errStr)
+	}
+	source := fmt.Sprintf("%s:%s", clusterIP, exportPath)
+	target := req.GetTargetPath()
+	mountOptions = getNFSMountOptions(req.VolumeContext)
+	defaultShareNfsVersion := req.VolumeContext[shareNfsVersion]
+	if defaultShareNfsVersion == "" {
+		defaultShareNfsVersion = "4"
+	}
+	nfsComandArgs := fmt.Sprintf("%s%s", NFS, defaultShareNfsVersion)
+	if len(mountOptions) == 0 {
+		// use default mount options, i.e (rw,relatime,vers=4.0,rsize=1048576,wsize=1048576,namlen=255,hard,proto=tcp,timeo=600,retrans=2,sec=sys,local_lock=none)
+		mountOptions = []string{
+			"nolock",
+			"vers=4",
+		}
+	}
+	mountOptions = append(mountOptions, fmt.Sprintf("addr=%s", clusterIP))
+	if req.GetReadonly() {
+		mountOptions = append(mountOptions, "ro")
+	}
+	if err := os.MkdirAll(target, 0750); err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+
+	if err := flavor.chapiDriver.MountNFSVolume(source, target, mountOptions, nfsComandArgs); err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+	return &csi.NodePublishVolumeResponse{}, nil
+}

--- a/pkg/flavor/kubernetes/flavor.go
+++ b/pkg/flavor/kubernetes/flavor.go
@@ -691,7 +691,7 @@ func (flavor *Flavor) getPodByName(name string, namespace string) (*v1.Pod, erro
 }
 
 // GetPVCByName to get the PVC details for given PVC name
-func (flavor *Flavor) GetPVCByName(name string, namespace string) (*v1.PersistentVolumeClaim , error) {
+func (flavor *Flavor) GetPVCByName(name string, namespace string) (*v1.PersistentVolumeClaim, error) {
 	log.Tracef(">>>>> GetPVCByName, name: %s, namespace: %s", name, namespace)
 	defer log.Trace("<<<<< GetPVCByName")
 
@@ -700,10 +700,9 @@ func (flavor *Flavor) GetPVCByName(name string, namespace string) (*v1.Persisten
 		log.Errorf("Error retrieving the pvc %s/%s, err: %v", namespace, name, err.Error())
 		return nil, err
 	}
-	
+
 	return pvc, nil
 }
-
 
 // makeVolumeHandle returns csi-<sha256(podUID,volSourceSpecName)>
 // Original source location: kubernetes/pkg/volume/csi/csi_mounter.go

--- a/pkg/flavor/types.go
+++ b/pkg/flavor/types.go
@@ -5,9 +5,9 @@ package flavor
 import (
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/hpe-storage/common-host-libs/model"
+	v1 "k8s.io/api/core/v1"
 	storage_v1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/version"
-	v1 "k8s.io/api/core/v1"
 )
 
 const (
@@ -44,5 +44,6 @@ type Flavor interface {
 	ListVolumeAttachments() (*storage_v1.VolumeAttachmentList, error)
 	GetChapCredentials(volumeContext map[string]string) (*model.ChapInfo, error)
 	CheckConnection() bool
-	GetPVCByName(name string, namespace string) (*v1.PersistentVolumeClaim , error) 
+	GetPVCByName(name string, namespace string) (*v1.PersistentVolumeClaim, error)
+	HandleFileNodePublish(request *csi.NodePublishVolumeRequest) (*csi.NodePublishVolumeResponse, error)
 }

--- a/pkg/flavor/vanilla/flavor.go
+++ b/pkg/flavor/vanilla/flavor.go
@@ -154,3 +154,8 @@ func (flavor *Flavor) CheckConnection() bool {
 func (flavor *Flavor) GetPVCByName(name string, namespace string) (*v1.PersistentVolumeClaim, error) {
 	return nil, nil
 }
+
+//nolint:revive
+func (flavor *Flavor) HandleFileNodePublish(request *csi.NodePublishVolumeRequest) (*csi.NodePublishVolumeResponse, error) {
+	return nil, status.Error(codes.Internal, "File provisioned volume is not supported for non-k8s environments")
+}


### PR DESCRIPTION
CON-3153 Support for Unified File in R5

CON-3240 Implement the csi-driver changes in CreateVolume to invoke the CSP.

CON-3217 Mount NFS volume to K8s cluster node

CON-3260 Add support for ExpandVolume from the csi-driver

CON-3305 POD Publish does not consider ArrayAccessIP change.