### PR TITLE
Add support for SUSE Linux Micro 6.1

### DIFF
--- a/cmd/csi-driver/conform/hpe-storage-node.sh
+++ b/cmd/csi-driver/conform/hpe-storage-node.sh
@@ -28,7 +28,7 @@ if [ -f /etc/os-release ]; then
     if [ $? -eq 0 ]; then
         CONFORM_TO=sles
     fi
-    echo $os_name | egrep -i "SLE Micro" >> /dev/null 2>&1
+    echo $os_name | egrep -i "SLE Micro|SL-Micro" >> /dev/null 2>&1
     if [ $? -eq 0 ]; then
         CONFORM_TO=slem
     fi


### PR DESCRIPTION
Allow **SL-Micro** NAME for SUSE Linux Micro 6.1

```
krtest-worker-m4q7z-lh6kl:/home/capv # cat /etc/os-release 
NAME="SL-Micro"
VERSION="6.1"
VERSION_ID="6.1"
PRETTY_NAME="SUSE Linux Micro 6.1"
ID="sl-micro"
ID_LIKE="suse sle-micro opensuse-microos microos"
ANSI_COLOR="0;32"
CPE_NAME="cpe:/o:suse:sl-micro:6.1"
HOME_URL="https://www.suse.com/products/micro/"
DOCUMENTATION_URL="https://documentation.suse.com/sl-micro/6.1/"
LOGO="distributor-logo"
```