### PR TITLE
CON 4206 - Volume gets cloned as wrong provisioning type - Bug Fix

### DIFF
--- a/pkg/driver/controller_server.go
+++ b/pkg/driver/controller_server.go
@@ -542,15 +542,15 @@ func (driver *Driver) createVolume(
 			// This ensures clone has same provisioning type as the original volume
 			if existingParentVolume.Config != nil {
 				if parentProvType, exists := existingParentVolume.Config["provisioning_type"]; exists {
-					createOptions["provisioning_type"] = parentProvType
 					// Normalize tdvv to reduce as backend only accepts tpvv or reduce
 					provTypeStr := fmt.Sprintf("%v", parentProvType)
 					if provTypeStr == "tdvv" {
-						createOptions["provisioning_type"] = "reduce"
+						provTypeStr = "reduce"
 						log.Infof("Inherited provisioning_type 'tdvv' from parent volume, normalized to 'reduce' for snapshot clone")
 					} else {
-						log.Infof("Inherited provisioning_type '%v' from parent volume for snapshot clone", parentProvType)
+						log.Infof("Inherited provisioning_type '%s' from parent volume for snapshot clone", provTypeStr)
 					}
+					createOptions["provisioning_type"] = provTypeStr
 				}
 			}
 


### PR DESCRIPTION
Bug Link - https://jira.storage.hpecorp.net/browse/CON-4206

Bug Description - Similarly, seen on PVC snapshot and restore when overriding the storage class to create a tpvv volume (originally storage class has "reduce" type) and when snapshot and restoring this PVC, the new cloned volume is created as reduce instead of tpvv.

Bug Fix- Added Code so as the PVC Created from shapshot always takes parent volume provisioning type only, also handed overrides such that if override is specified we remove the storageclass provisioning type and only consider PVC provisioning type to avoid conflict.

Earlier Screenshots
![image](https://github.com/user-attachments/assets/e3f6b5e5-071f-470e-8614-891e7c2e0903)


After Fixing Bug
<img width="798" height="152" alt="image" src="https://github.com/user-attachments/assets/7e7c9ed1-eb37-4d1b-ab9b-5a4afa045ab7" />
