### PR TITLE
CON-2683 Duplicate IQNs shouldn't be allowed in hpenodeinfo

### DIFF
--- a/pkg/flavor/kubernetes/flavor.go
+++ b/pkg/flavor/kubernetes/flavor.go
@@ -223,6 +223,15 @@ func (flavor *Flavor) LoadNodeInfo(node *model.Node) (string, error) {
 		}
 		// update node initiator IQNs on mismatch
 		iqnsFromNode := getIqnsFromNode(node)
+		wwpnsFromNode := getWwpnsFromNode(node)
+		nqnsFromNode := getNqnsFromNode(node)
+
+		if err := flavor.validateUniqueInitiators(node.Name, iqnsFromNode, wwpnsFromNode, nqnsFromNode); err != nil {
+			log.Errorf("Initiator validation failed: %s", err.Error())
+			return "", err
+		}
+
+		// update node initiator IQNs on mismatch
 		if !reflect.DeepEqual(nodeInfo.Spec.IQNs, iqnsFromNode) {
 			nodeInfo.Spec.IQNs = iqnsFromNode
 			updateNodeRequired = true
@@ -234,12 +243,11 @@ func (flavor *Flavor) LoadNodeInfo(node *model.Node) (string, error) {
 			updateNodeRequired = true
 		}
 		// update node FC port WWPNs on mismatch
-		wwpnsFromNode := getWwpnsFromNode(node)
 		if !reflect.DeepEqual(nodeInfo.Spec.WWPNs, wwpnsFromNode) {
 			nodeInfo.Spec.WWPNs = wwpnsFromNode
 			updateNodeRequired = true
 		}
-		nqnsFromNode := getNqnsFromNode(node)
+		// update node NQNs on mismatch
 		if !reflect.DeepEqual(nodeInfo.Spec.NQNs, nqnsFromNode) {
 			nodeInfo.Spec.NQNs = nqnsFromNode
 			updateNodeRequired = true
@@ -258,6 +266,15 @@ func (flavor *Flavor) LoadNodeInfo(node *model.Node) (string, error) {
 		}
 	} else {
 		// if we didn't find HPENodeInfo yet, create one.
+		// Validate initiators before creating new node
+		iqnsFromNode := getIqnsFromNode(node)
+		wwpnsFromNode := getWwpnsFromNode(node)
+		nqnsFromNode := getNqnsFromNode(node)
+
+		if err := flavor.validateUniqueInitiators(node.Name, iqnsFromNode, wwpnsFromNode, nqnsFromNode); err != nil {
+			log.Errorf("Initiator validation failed: %s", err.Error())
+			return "", err
+		}
 		newNodeInfo := &crd_v1.HPENodeInfo{
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name: node.Name,
@@ -284,6 +301,75 @@ func (flavor *Flavor) LoadNodeInfo(node *model.Node) (string, error) {
 
 	return node.UUID, nil
 }
+
+// validateUniqueInitiators checks if IQNs/WWPNs/NQNs from the current node 
+// already exist in other nodes' HPENodeInfo CRs
+func (flavor *Flavor) validateUniqueInitiators(nodeName string, iqns, wwpns, nqns []string) error {
+    log.Tracef(">>>>> validateUniqueInitiators for node %s", nodeName)
+    defer log.Trace("<<<<< validateUniqueInitiators")
+    
+    // Get all existing HPENodeInfo objects
+    nodeInfoList, err := flavor.crdClient.StorageV1().HPENodeInfos().List(meta_v1.ListOptions{})
+    if err != nil {
+        return fmt.Errorf("failed to list HPENodeInfos: %v", err)
+    }
+    
+    // Check each existing node (except the current one)
+    for _, existingNodeInfo := range nodeInfoList.Items {
+        if existingNodeInfo.Name == nodeName {
+            continue // Skip self
+        }
+        
+        // Check for duplicate IQNs
+        for _, currentIQN := range iqns {
+            if currentIQN == "" {
+                continue // Skip empty
+            }
+            for _, existingIQN := range existingNodeInfo.Spec.IQNs {
+                if strings.EqualFold(currentIQN, existingIQN) {
+                    return fmt.Errorf(
+                        "CRITICAL: Duplicate IQN '%s' detected on node '%s' (attempting to register on node '%s'). "+
+                        "This will cause data corruption. Each node must have unique iSCSI initiator names. "+
+                        "Please regenerate IQNs or fix node templates before proceeding",
+                        currentIQN, existingNodeInfo.Name, nodeName)
+                }
+            }
+        }
+        
+        // Check for duplicate WWPNs
+        for _, currentWWPN := range wwpns {
+            if currentWWPN == "" {
+                continue
+            }
+            for _, existingWWPN := range existingNodeInfo.Spec.WWPNs {
+                if strings.EqualFold(currentWWPN, existingWWPN) {
+                    return fmt.Errorf(
+                        "CRITICAL: Duplicate WWPN '%s' detected on node '%s' (attempting to register on node '%s'). "+
+                        "This will cause data corruption. Each node must have unique Fibre Channel WWPNs",
+                        currentWWPN, existingNodeInfo.Name, nodeName)
+                }
+            }
+        }
+        
+        // Check for duplicate NQNs
+        for _, currentNQN := range nqns {
+            if currentNQN == "" {
+                continue
+            }
+            for _, existingNQN := range existingNodeInfo.Spec.NQNs {
+                if strings.EqualFold(currentNQN, existingNQN) {
+                    return fmt.Errorf(
+                        "CRITICAL: Duplicate NQN '%s' detected on node '%s' (attempting to register on node '%s'). "+
+                        "This will cause data corruption. Each node must have unique NVMe Qualified Names",
+                        currentNQN, existingNodeInfo.Name, nodeName)
+                }
+            }
+        }
+    }
+    
+    return nil
+}
+
 
 func getIqnsFromNode(node *model.Node) []string {
 	var iqns []string

--- a/pkg/flavor/kubernetes/flavor_test.go
+++ b/pkg/flavor/kubernetes/flavor_test.go
@@ -1,0 +1,283 @@
+// Copyright 2019, 2025 Hewlett Packard Enterprise Development LP
+
+package kubernetes
+
+import (
+	"fmt"
+	"testing"
+
+	crd_v1 "github.com/hpe-storage/k8s-custom-resources/pkg/apis/hpestorage/v1"
+	"github.com/stretchr/testify/assert"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// validateUniqueInitiatorsForTest is a test-only version that takes node list directly
+// This avoids needing to mock the CRD client and tests the core validation logic
+func validateUniqueInitiatorsForTest(nodeName string, iqns, wwpns, nqns []string, existingNodes []crd_v1.HPENodeInfo) error {
+	// Check each existing node (except the current one)
+	for _, existingNodeInfo := range existingNodes {
+		if existingNodeInfo.Name == nodeName {
+			continue // Skip self
+		}
+
+		// Check for duplicate IQNs
+		for _, currentIQN := range iqns {
+			if currentIQN == "" {
+				continue // Skip empty
+			}
+			for _, existingIQN := range existingNodeInfo.Spec.IQNs {
+				if currentIQN == existingIQN {
+					return fmt.Errorf(
+						"CRITICAL: Duplicate IQN '%s' detected on node '%s' (attempting to register on node '%s'). "+
+							"This will cause data corruption. Each node must have unique iSCSI initiator names. "+
+							"Please regenerate IQNs or fix node templates before proceeding",
+						currentIQN, existingNodeInfo.Name, nodeName)
+				}
+			}
+		}
+
+		// Check for duplicate WWPNs
+		for _, currentWWPN := range wwpns {
+			if currentWWPN == "" {
+				continue
+			}
+			for _, existingWWPN := range existingNodeInfo.Spec.WWPNs {
+				if currentWWPN == existingWWPN {
+					return fmt.Errorf(
+						"CRITICAL: Duplicate WWPN '%s' detected on node '%s' (attempting to register on node '%s'). "+
+							"This will cause data corruption. Each node must have unique Fibre Channel WWPNs",
+						currentWWPN, existingNodeInfo.Name, nodeName)
+				}
+			}
+		}
+
+		// Check for duplicate NQNs
+		for _, currentNQN := range nqns {
+			if currentNQN == "" {
+				continue
+			}
+			for _, existingNQN := range existingNodeInfo.Spec.NQNs {
+				if currentNQN == existingNQN {
+					return fmt.Errorf(
+						"CRITICAL: Duplicate NQN '%s' detected on node '%s' (attempting to register on node '%s'). "+
+							"This will cause data corruption. Each node must have unique NVMe Qualified Names",
+						currentNQN, existingNodeInfo.Name, nodeName)
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func TestValidateUniqueInitiators(t *testing.T) {
+	tests := []struct {
+		name           string
+		existingNodes  []crd_v1.HPENodeInfo
+		newNodeName    string
+		newIQNs        []string
+		newWWPNs       []string
+		newNQNs        []string
+		expectError    bool
+		errorSubstring string
+	}{
+		{
+			name: "No duplicate IQNs - should succeed",
+			existingNodes: []crd_v1.HPENodeInfo{
+				{
+					ObjectMeta: meta_v1.ObjectMeta{Name: "node1"},
+					Spec: crd_v1.HPENodeInfoSpec{
+						IQNs:  []string{"iqn.1994-05.com.redhat:node1"},
+						WWPNs: []string{"10:00:00:00:c9:a1:b2:c3"},
+						NQNs:  []string{"nqn.2014-08.org.nvmexpress:uuid:node1"},
+					},
+				},
+			},
+			newNodeName: "node2",
+			newIQNs:     []string{"iqn.1994-05.com.redhat:node2"},
+			newWWPNs:    []string{"10:00:00:00:c9:a1:b2:c4"},
+			newNQNs:     []string{"nqn.2014-08.org.nvmexpress:uuid:node2"},
+			expectError: false,
+		},
+		{
+			name: "Duplicate IQN detected - should fail",
+			existingNodes: []crd_v1.HPENodeInfo{
+				{
+					ObjectMeta: meta_v1.ObjectMeta{Name: "node1"},
+					Spec: crd_v1.HPENodeInfoSpec{
+						IQNs:  []string{"iqn.1994-05.com.redhat:duplicated"},
+						WWPNs: []string{"10:00:00:00:c9:a1:b2:c3"},
+						NQNs:  []string{"nqn.2014-08.org.nvmexpress:uuid:node1"},
+					},
+				},
+			},
+			newNodeName:    "node2",
+			newIQNs:        []string{"iqn.1994-05.com.redhat:duplicated"},
+			newWWPNs:       []string{"10:00:00:00:c9:a1:b2:c4"},
+			newNQNs:        []string{"nqn.2014-08.org.nvmexpress:uuid:node2"},
+			expectError:    true,
+			errorSubstring: "Duplicate IQN 'iqn.1994-05.com.redhat:duplicated' detected on node 'node1'",
+		},
+		{
+			name: "Duplicate WWPN detected - should fail",
+			existingNodes: []crd_v1.HPENodeInfo{
+				{
+					ObjectMeta: meta_v1.ObjectMeta{Name: "node1"},
+					Spec: crd_v1.HPENodeInfoSpec{
+						IQNs:  []string{"iqn.1994-05.com.redhat:node1"},
+						WWPNs: []string{"10:00:00:00:c9:a1:b2:c3"},
+						NQNs:  []string{"nqn.2014-08.org.nvmexpress:uuid:node1"},
+					},
+				},
+			},
+			newNodeName:    "node2",
+			newIQNs:        []string{"iqn.1994-05.com.redhat:node2"},
+			newWWPNs:       []string{"10:00:00:00:c9:a1:b2:c3"}, // Duplicate
+			newNQNs:        []string{"nqn.2014-08.org.nvmexpress:uuid:node2"},
+			expectError:    true,
+			errorSubstring: "Duplicate WWPN '10:00:00:00:c9:a1:b2:c3' detected on node 'node1'",
+		},
+		{
+			name: "Duplicate NQN detected - should fail",
+			existingNodes: []crd_v1.HPENodeInfo{
+				{
+					ObjectMeta: meta_v1.ObjectMeta{Name: "node1"},
+					Spec: crd_v1.HPENodeInfoSpec{
+						IQNs:  []string{"iqn.1994-05.com.redhat:node1"},
+						WWPNs: []string{"10:00:00:00:c9:a1:b2:c3"},
+						NQNs:  []string{"nqn.2014-08.org.nvmexpress:uuid:duplicated"},
+					},
+				},
+			},
+			newNodeName:    "node2",
+			newIQNs:        []string{"iqn.1994-05.com.redhat:node2"},
+			newWWPNs:       []string{"10:00:00:00:c9:a1:b2:c4"},
+			newNQNs:        []string{"nqn.2014-08.org.nvmexpress:uuid:duplicated"}, // Duplicate
+			expectError:    true,
+			errorSubstring: "Duplicate NQN 'nqn.2014-08.org.nvmexpress:uuid:duplicated' detected on node 'node1'",
+		},
+		{
+			name: "Same node updating its own initiators - should succeed",
+			existingNodes: []crd_v1.HPENodeInfo{
+				{
+					ObjectMeta: meta_v1.ObjectMeta{Name: "node1"},
+					Spec: crd_v1.HPENodeInfoSpec{
+						IQNs:  []string{"iqn.1994-05.com.redhat:node1"},
+						WWPNs: []string{"10:00:00:00:c9:a1:b2:c3"},
+						NQNs:  []string{"nqn.2014-08.org.nvmexpress:uuid:node1"},
+					},
+				},
+			},
+			newNodeName: "node1", // Same node
+			newIQNs:     []string{"iqn.1994-05.com.redhat:node1"},
+			newWWPNs:    []string{"10:00:00:00:c9:a1:b2:c3"},
+			newNQNs:     []string{"nqn.2014-08.org.nvmexpress:uuid:node1"},
+			expectError: false,
+		},
+		{
+			name: "Empty initiators - should succeed",
+			existingNodes: []crd_v1.HPENodeInfo{
+				{
+					ObjectMeta: meta_v1.ObjectMeta{Name: "node1"},
+					Spec: crd_v1.HPENodeInfoSpec{
+						IQNs:  []string{"iqn.1994-05.com.redhat:node1"},
+						WWPNs: []string{},
+						NQNs:  []string{},
+					},
+				},
+			},
+			newNodeName: "node2",
+			newIQNs:     []string{},
+			newWWPNs:    []string{},
+			newNQNs:     []string{},
+			expectError: false,
+		},
+		{
+			name: "Multiple IQNs with one duplicate - should fail",
+			existingNodes: []crd_v1.HPENodeInfo{
+				{
+					ObjectMeta: meta_v1.ObjectMeta{Name: "node1"},
+					Spec: crd_v1.HPENodeInfoSpec{
+						IQNs:  []string{"iqn.1994-05.com.redhat:node1a", "iqn.1994-05.com.redhat:node1b"},
+						WWPNs: []string{},
+						NQNs:  []string{},
+					},
+				},
+			},
+			newNodeName:    "node2",
+			newIQNs:        []string{"iqn.1994-05.com.redhat:node2a", "iqn.1994-05.com.redhat:node1b"}, // Second is duplicate
+			newWWPNs:       []string{},
+			newNQNs:        []string{},
+			expectError:    true,
+			errorSubstring: "Duplicate IQN 'iqn.1994-05.com.redhat:node1b'",
+		},
+		{
+			name: "Multiple nodes - duplicate on second node",
+			existingNodes: []crd_v1.HPENodeInfo{
+				{
+					ObjectMeta: meta_v1.ObjectMeta{Name: "node1"},
+					Spec: crd_v1.HPENodeInfoSpec{
+						IQNs:  []string{"iqn.1994-05.com.redhat:node1"},
+						WWPNs: []string{},
+						NQNs:  []string{},
+					},
+				},
+				{
+					ObjectMeta: meta_v1.ObjectMeta{Name: "node2"},
+					Spec: crd_v1.HPENodeInfoSpec{
+						IQNs:  []string{"iqn.1994-05.com.redhat:duplicated"},
+						WWPNs: []string{},
+						NQNs:  []string{},
+					},
+				},
+			},
+			newNodeName:    "node3",
+			newIQNs:        []string{"iqn.1994-05.com.redhat:duplicated"},
+			newWWPNs:       []string{},
+			newNQNs:        []string{},
+			expectError:    true,
+			errorSubstring: "Duplicate IQN",
+		},
+		{
+			name: "Empty string IQN should be skipped",
+			existingNodes: []crd_v1.HPENodeInfo{
+				{
+					ObjectMeta: meta_v1.ObjectMeta{Name: "node1"},
+					Spec: crd_v1.HPENodeInfoSpec{
+						IQNs:  []string{""},
+						WWPNs: []string{},
+						NQNs:  []string{},
+					},
+				},
+			},
+			newNodeName: "node2",
+			newIQNs:     []string{""},
+			newWWPNs:    []string{},
+			newNQNs:     []string{},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Test the validation logic directly with existing nodes
+			err := validateUniqueInitiatorsForTest(
+				tt.newNodeName,
+				tt.newIQNs,
+				tt.newWWPNs,
+				tt.newNQNs,
+				tt.existingNodes,
+			)
+
+			if tt.expectError {
+				assert.Error(t, err, "Expected an error but got none")
+				if tt.errorSubstring != "" {
+					assert.Contains(t, err.Error(), tt.errorSubstring, "Error message should contain expected substring")
+				}
+				assert.Contains(t, err.Error(), "CRITICAL", "Error should be marked as CRITICAL")
+			} else {
+				assert.NoError(t, err, "Expected no error but got: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
JIRA Link : https://jira.storage.hpecorp.net/browse/CON-2683

Bug Description: Duplicate IQNs shouldn't be allowed in hpenodeinfo

Bug Fix: 
In this setup, a Kubernetes cluster was created using three virtual machines:

- One master node (rashi-master)
- One worker node created normally (rashi-worker1)
- One additional worker node (rashi-worker2) created by cloning the rashi-worker1 VM

After cloning, rashi-worker2 was configured and joined to the Kubernetes cluster. As a result, both worker nodes (rashi-worker1 and rashi-worker2) has an identical IQN.


As part of this fix the CSI node driver checks if an IQN is already used by another node before registering. When rashi-worker2 starts, it detects that the IQN already exists for rashi-worker1 and stops the node driver from registering.
Due to this, rashi-worker2 is not added to the HPENodeInfos list.

This behavior is also visible in the logs, where a critical error message is printed indicating that a duplicate IQN was detected and node registration was blocked to prevent data corruption.
