### PR TITLE
Final rework of CON-3010, CON-4174 and CON-4402

### DIFF
--- a/pkg/driver/constants.go
+++ b/pkg/driver/constants.go
@@ -128,7 +128,4 @@ const (
 	defaultCSITopologyKey = "csi.hpe.com/zone"
 	// FileSystem Corruption parameters
 	fsRepairKey          = "fsRepair"
-	serviceNameKey       = "serviceName"
-	pvNameAttribute      = "csi.storage.k8s.io/pv/name"
-	nimbleCSPServiceName = "nimble-csp-svc"
 )

--- a/pkg/flavor/kubernetes/flavor.go
+++ b/pkg/flavor/kubernetes/flavor.go
@@ -795,38 +795,6 @@ func (flavor *Flavor) getPodByName(name string, namespace string) (*v1.Pod, erro
 	return pod, nil
 }
 
-// GetPVCByVolumeID to get the PVC details for given volumeID
-func (flavor *Flavor) GetPVCByVolumeID(id string) (*v1.PersistentVolumeClaim, error) {
-	log.Tracef(">>>>> GetPVCByVolumeID, id: %s", id)
-	defer log.Trace("<<<<< GetPVCByVolumeID")
-
-	pv, err := flavor.kubeClient.CoreV1().PersistentVolumes().Get(context.Background(), id, meta_v1.GetOptions{})
-
-	if err != nil {
-		log.Errorf("Error retrieving the ID %s, err: %v", id, err.Error())
-		return nil, err
-	}
-
-	if pv.Spec.ClaimRef != nil {
-
-		namespace := pv.Spec.ClaimRef.Namespace
-		name := pv.Spec.ClaimRef.Name
-
-		pvc, err := flavor.kubeClient.CoreV1().PersistentVolumeClaims(namespace).Get(context.Background(), name, meta_v1.GetOptions{})
-		if err != nil {
-			log.Errorf("Error retrieving the PVC name %s in Namespace %s from claimRef of PV %s, error: %v", name, namespace, id, err.Error())
-			return nil, err
-		}
-
-		return pvc, nil
-
-	} else {
-		err := fmt.Errorf("Error retrieving the claimRef of %s", id)
-		log.Errorf("%v", err.Error())
-		return nil, err
-	}
-}
-
 // makeVolumeHandle returns csi-<sha256(podUID,volSourceSpecName)>
 // Original source location: kubernetes/pkg/volume/csi/csi_mounter.go
 // TODO: Must be in-sync with k8s code

--- a/pkg/flavor/types.go
+++ b/pkg/flavor/types.go
@@ -45,6 +45,5 @@ type Flavor interface {
 	ListVolumeAttachments() (*storage_v1.VolumeAttachmentList, error)
 	GetChapCredentials(volumeContext map[string]string) (*model.ChapInfo, error)
 	CheckConnection() bool
-	GetPVCByVolumeID(id string) (*v1.PersistentVolumeClaim, error)
 	HandleFileNodePublish(request *csi.NodePublishVolumeRequest) (*csi.NodePublishVolumeResponse, error)
 }

--- a/pkg/flavor/vanilla/flavor.go
+++ b/pkg/flavor/vanilla/flavor.go
@@ -155,11 +155,6 @@ func (flavor *Flavor) CheckConnection() bool {
 }
 
 //nolint:revive
-func (flavor *Flavor) GetPVCByVolumeID(id string) (*v1.PersistentVolumeClaim, error) {
-	return nil, nil
-}
-
-//nolint:revive
 func (flavor *Flavor) HandleFileNodePublish(request *csi.NodePublishVolumeRequest) (*csi.NodePublishVolumeResponse, error) {
 	return nil, status.Error(codes.Internal, "File provisioned volume is not supported for non-k8s environments")
 }


### PR DESCRIPTION
- Passes e2e for Nimble and 3PAR including expand on clones tests.
- All node stages checks for resize on non-ephemeral volumes.
- Surprise feature: offline and controller expansion seems to work
- Tested with #509 patched in (not part of this PR)