### PR TITLE
CON-4177 Static provisioning with Unified File is failing when attaching PVC to Pod

### DIFF
--- a/pkg/driver/controller_server.go
+++ b/pkg/driver/controller_server.go
@@ -894,10 +894,45 @@ func (driver *Driver) controllerPublishVolume(
 				fmt.Sprintf("File volume with name %s not found", volumeID))
 		}
 
+		// Check if volume already has export info in Config (e.g., Unified File static provisioning)
+		if volume.Config != nil {
+			exportIP, hasExportIP := volume.Config["hostIP"]
+			mountPath, hasMountPath := volume.Config["mountPath"]
+			if hasExportIP && hasMountPath {
+				log.Infof("Volume %s (ID: %s) already has export info, skipping PublishFileVolume", volumeID, volume.ID)
+				return map[string]string{
+					readOnlyKey:     strconv.FormatBool(readOnlyAccessMode),
+					fileExportIPKey: fmt.Sprintf("%v", exportIP),
+					mountPathKey:    fmt.Sprintf("%v", mountPath),
+				}, nil
+			}
+		}
+
 		// Use the actual volume ID (not the name) for publishing
 		publishFileVol, err := storageProvider.PublishFileVolume(volume.ID, publishOptions)
 		if err != nil {
-			log.Errorf("Failed to publish file volume %s (ID: %s), err: %s", volumeID, volume.ID, err.Error())
+			log.Warnf("PublishFileVolume failed for volume %s (ID: %s), err: %s. Attempting to get volume info directly.", volumeID, volume.ID, err.Error())
+			// Fallback: for Unified File volumes, PublishFileVolume may not be supported.
+			// Try to get the volume info directly which may contain hostip and mountpath.
+			fallbackVol, getErr := storageProvider.GetVolume(volume.ID)
+			if getErr != nil || fallbackVol == nil {
+				log.Errorf("Fallback GetVolume also failed for volume %s (ID: %s), err: %v", volumeID, volume.ID, getErr)
+				return nil, status.Error(codes.Internal,
+					fmt.Sprintf("Failed to add file share settings access for volume %s (ID: %s) for node %s via File CSP, err: %s", volumeID, volume.ID, nodeID, err.Error()))
+			}
+			if fallbackVol.Config != nil {
+				exportIP, hasExportIP := fallbackVol.Config["hostIP"]
+				mountPath, hasMountPath := fallbackVol.Config["mountPath"]
+				if hasExportIP && hasMountPath {
+					log.Infof("Fallback succeeded: got exportIP and mountPath for volume %s (ID: %s)", volumeID, volume.ID)
+					return map[string]string{
+						readOnlyKey:     strconv.FormatBool(readOnlyAccessMode),
+						fileExportIPKey: fmt.Sprintf("%v", exportIP),
+						mountPathKey:    fmt.Sprintf("%v", mountPath),
+					}, nil
+				}
+			}
+			log.Errorf("Fallback GetVolume did not return exportIP/mountPath for volume %s (ID: %s)", volumeID, volume.ID)
 			return nil, status.Error(codes.Internal,
 				fmt.Sprintf("Failed to add file share settings access for volume %s (ID: %s) for node %s via File CSP, err: %s", volumeID, volume.ID, nodeID, err.Error()))
 		}

--- a/pkg/driver/controller_server.go
+++ b/pkg/driver/controller_server.go
@@ -882,12 +882,24 @@ func (driver *Driver) controllerPublishVolume(
 			return nil, status.Error(codes.Unavailable,
 				fmt.Sprintf("Failed to get storage provider from secrets, err: %s", err.Error()))
 		}
-
-		publishFileVol, err := storageProvider.PublishFileVolume(volumeID, publishOptions)
+		// For file volumes, volumeID might be a name, so get the actual volume object first
+		volume, err := storageProvider.GetVolumeByName(volumeID)
 		if err != nil {
-			log.Errorf("Failed to publish volume %s, err: %s", volumeID, err.Error())
+			log.Errorf("Failed to get file volume by name %s, err: %s", volumeID, err.Error())
 			return nil, status.Error(codes.Internal,
-				fmt.Sprintf("Failed to add file share settings access for volume %s for node %s via File CSP, err: %s", volumeID, nodeID, err.Error()))
+				fmt.Sprintf("Failed to get file volume %s, err: %s", volumeID, err.Error()))
+		}
+		if volume == nil {
+			return nil, status.Error(codes.NotFound,
+				fmt.Sprintf("File volume with name %s not found", volumeID))
+		}
+
+		// Use the actual volume ID (not the name) for publishing
+		publishFileVol, err := storageProvider.PublishFileVolume(volume.ID, publishOptions)
+		if err != nil {
+			log.Errorf("Failed to publish file volume %s (ID: %s), err: %s", volumeID, volume.ID, err.Error())
+			return nil, status.Error(codes.Internal,
+				fmt.Sprintf("Failed to add file share settings access for volume %s (ID: %s) for node %s via File CSP, err: %s", volumeID, volume.ID, nodeID, err.Error()))
 		}
 
 		log.Info("ControllerPublish requested with file resources, returning success")
@@ -899,7 +911,7 @@ func (driver *Driver) controllerPublishVolume(
 	}
 
 	// Get Volume using secrets
-	volume, err := driver.GetVolumeByID(volumeID, secrets)
+	volume, err := driver.GetVolumeByName(volumeID, secrets)
 	if err != nil {
 		log.Errorf("Failed to get volume %s, err: %s", volumeID, err.Error())
 		return nil, err

--- a/pkg/driver/node_server.go
+++ b/pkg/driver/node_server.go
@@ -894,12 +894,48 @@ func (driver *Driver) NodePublishVolume(ctx context.Context, request *csi.NodePu
 	// Check if volume is requested with File resources and intercept here
 	if driver.IsFileRequest(request.VolumeContext) {
 		log.Infof("NodePublish requested with file resources for %s", request.VolumeId)
-		if request.PublishContext == nil {
-			return nil, status.Error(codes.InvalidArgument,
-				fmt.Sprintf("publish context is nil for file volume %s", request.VolumeId))
+		existingVolume, err := driver.GetVolumeByName(request.VolumeId, request.Secrets)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get volume %s, err: %s", request.VolumeId, err.Error())
 		}
+		if existingVolume.Config != nil {
+			hostIPVal, ok := existingVolume.Config[fileExportIPKey]
+			if ok && hostIPVal != nil {
+				hostIP, ok := hostIPVal.(string)
+				if ok && hostIP != "" && isValidIP(hostIP) {
+					log.Infof("Adding hostIP %s to volume context for volume %s", hostIP, request.VolumeId)
+					request.VolumeContext[fileExportIPKey] = hostIP
+				} else {
+					log.Errorf("failed to get hostIP for volume %s", request.VolumeId)
+					return nil, fmt.Errorf("failed to get hostIP for volume %s", request.VolumeId)
+				}
+			} else {
+				log.Errorf("hostIP key not found or value is nil in config for volume %s", request.VolumeId)
+				return nil, fmt.Errorf("hostIP key not found or value is nil in config for volume %s", request.VolumeId)
+			}
+			// Also extract mountPath from Config
+			mountPathVal, ok := existingVolume.Config["mountPath"]
+			if ok && mountPathVal != nil {
+				mountPath, ok := mountPathVal.(string)
+				if ok && mountPath != "" {
+					log.Infof("Adding mountPath %s to volume context for volume %s", mountPath, request.VolumeId)
+					request.VolumeContext["mountPath"] = mountPath
+				} else {
+					log.Errorf("failed to get mountPath for volume %s", request.VolumeId)
+					return nil, fmt.Errorf("failed to get mountPath for volume %s", request.VolumeId)
+				}
+			} else {
+				log.Errorf("mountPath key not found or value is nil in config for volume %s", request.VolumeId)
+				return nil, fmt.Errorf("mountPath key not found or value is nil in config for volume %s", request.VolumeId)
+			}
+		} else {
+			log.Errorf("config is nil for volume %s", request.VolumeId)
+			return nil, fmt.Errorf("config is nil for volume %s", request.VolumeId)
+		}
+
 		mountOptions := getMountOptionsFromVolCap(request.VolumeCapability)
 		return driver.flavor.HandleFileNodePublish(request, mountOptions)
+
 	}
 	// If ephemeral volume request, then create new volume, add ACL and NodeStage/NodePublish
 	if ephemeral {

--- a/pkg/driver/node_server.go
+++ b/pkg/driver/node_server.go
@@ -899,7 +899,7 @@ func (driver *Driver) NodePublishVolume(ctx context.Context, request *csi.NodePu
 			return nil, fmt.Errorf("failed to get volume %s, err: %s", request.VolumeId, err.Error())
 		}
 		if existingVolume.Config != nil {
-			hostIPVal, ok := existingVolume.Config[fileExportIPKey]
+			hostIPVal, ok := existingVolume.Config["hostIP"]
 			if ok && hostIPVal != nil {
 				hostIP, ok := hostIPVal.(string)
 				if ok && hostIP != "" && isValidIP(hostIP) {

--- a/vendor/github.com/hpe-storage/common-host-libs/storageprovider/csp/container_storage_provider.go
+++ b/vendor/github.com/hpe-storage/common-host-libs/storageprovider/csp/container_storage_provider.go
@@ -696,7 +696,7 @@ func (provider *ContainerStorageProvider) GetVolume(id string) (*model.Volume, e
 
 // GetVolumeByName will return information about the given volume
 func (provider *ContainerStorageProvider) GetVolumeByName(name string) (*model.Volume, error) {
-	response := make([]*model.Volume, 0)
+	var rawResponse map[string]interface{}
 	var errorResponse *ErrorsPayload
 
 	status, err := provider.invoke(
@@ -704,7 +704,7 @@ func (provider *ContainerStorageProvider) GetVolumeByName(name string) (*model.V
 			Action:        "GET",
 			Path:          fmt.Sprintf("/containers/v1/volumes?name=%s", name),
 			Payload:       nil,
-			Response:      &response,
+			Response:      &rawResponse,
 			ResponseError: &errorResponse,
 		},
 	)
@@ -715,22 +715,37 @@ func (provider *ContainerStorageProvider) GetVolumeByName(name string) (*model.V
 	if errorResponse != nil {
 		return nil, handleError(status, errorResponse)
 	}
+	// Detect response format and extract volume
+	if dataArray, hasData := rawResponse["data"].([]interface{}); hasData {
+		log.Trace("Detected CSP response format with data array")
+		if len(dataArray) == 0 {
+			log.Errorf("Could not find volume %s in json response", name)
+			return nil, fmt.Errorf("Could not find volume named %s in json response", name)
+		}
 
-	// there should only be one volume
-	values := reflect.ValueOf(response)
-	if values.Len() == 0 {
+		volume := &model.Volume{}
+		err = jsonutil.Decode(dataArray[0], volume)
+		if err != nil {
+			return nil, fmt.Errorf("Error while decoding the volume response, err: %s", err.Error())
+		}
+		log.Tracef("Found volume: %s with ID: %s", volume.Name, volume.ID)
+		return volume, nil
+	}
+
+	log.Trace("Attempting to parse as direct array response")
+	response := make([]*model.Volume, 0)
+	err = jsonutil.Decode(rawResponse, &response)
+	if err != nil {
+		return nil, fmt.Errorf("Error while decoding volume response, unsupported format, err: %s", err.Error())
+	}
+
+	if len(response) == 0 {
 		log.Errorf("Could not find volume %s in json response", name)
 		return nil, fmt.Errorf("Could not find volume named %s in json response", name)
 	}
-	log.Tracef("Found %d volumes", values.Len())
 
-	volume := &model.Volume{}
-	err = jsonutil.Decode(values.Index(0).Interface(), volume)
-	if err != nil {
-		return nil, fmt.Errorf("Error while decoding the volume response, err: %s", err.Error())
-	}
-
-	return volume, err
+	log.Tracef("Found %d volumes", len(response))
+	return response[0], nil
 }
 
 // GetVolumes returns all of the volumes from the CSP

--- a/vendor/github.com/hpe-storage/common-host-libs/storageprovider/csp/container_storage_provider.go
+++ b/vendor/github.com/hpe-storage/common-host-libs/storageprovider/csp/container_storage_provider.go
@@ -665,7 +665,7 @@ func (provider *ContainerStorageProvider) EditVolume(id string, opts map[string]
 
 // GetVolume will return information about the given volume
 func (provider *ContainerStorageProvider) GetVolume(id string) (*model.Volume, error) {
-	response := &model.Volume{}
+	var rawResponse map[string]interface{}
 	var errorResponse *ErrorsPayload
 	var status int
 	var err error
@@ -674,14 +674,10 @@ func (provider *ContainerStorageProvider) GetVolume(id string) (*model.Volume, e
 			Action:        "GET",
 			Path:          fmt.Sprintf("/containers/v1/volumes/%s", id),
 			Payload:       nil,
-			Response:      &response,
+			Response:      &rawResponse,
 			ResponseError: &errorResponse,
 		},
 	)
-
-	if status == http.StatusOK {
-		return response, nil
-	}
 
 	if status == http.StatusNotFound {
 		return nil, nil
@@ -691,7 +687,17 @@ func (provider *ContainerStorageProvider) GetVolume(id string) (*model.Volume, e
 		return nil, handleError(status, errorResponse)
 	}
 
-	return nil, err
+	if err != nil {
+		return nil, err
+	}
+
+	volume := &model.Volume{}
+	err = jsonutil.Decode(rawResponse, volume)
+	if err != nil {
+		return nil, fmt.Errorf("Error while decoding volume response, err: %s", err.Error())
+	}
+
+	return volume, nil
 }
 
 // GetVolumeByName will return information about the given volume
@@ -715,6 +721,7 @@ func (provider *ContainerStorageProvider) GetVolumeByName(name string) (*model.V
 	if errorResponse != nil {
 		return nil, handleError(status, errorResponse)
 	}
+
 	// Detect response format and extract volume
 	if dataArray, hasData := rawResponse["data"].([]interface{}); hasData {
 		log.Trace("Detected CSP response format with data array")
@@ -727,6 +734,48 @@ func (provider *ContainerStorageProvider) GetVolumeByName(name string) (*model.V
 		err = jsonutil.Decode(dataArray[0], volume)
 		if err != nil {
 			return nil, fmt.Errorf("Error while decoding the volume response, err: %s", err.Error())
+		}
+		log.Tracef("Found volume: %s with ID: %s", volume.Name, volume.ID)
+		return volume, nil
+	}
+
+	// Check for "members" map format (e.g., Unified File CSP response)
+	if membersRaw, hasMembers := rawResponse["members"]; hasMembers {
+		log.Trace("Detected members map response format")
+		membersMap, ok := membersRaw.(map[string]interface{})
+		if ok {
+			for uid, memberRaw := range membersMap {
+				memberData, ok := memberRaw.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				memberName, _ := memberData["name"].(string)
+				if memberName == name {
+					log.Tracef("Found matching volume %s with uid %s in members map", name, uid)
+					volume := &model.Volume{}
+					err = jsonutil.Decode(memberData, volume)
+					if err != nil {
+						return nil, fmt.Errorf("Error while decoding member volume response, err: %s", err.Error())
+					}
+					if volume.ID == "" {
+						volume.ID = uid
+					}
+					log.Tracef("Found volume: %s with ID: %s", volume.Name, volume.ID)
+					return volume, nil
+				}
+			}
+			log.Errorf("Could not find volume %s in members map", name)
+			return nil, fmt.Errorf("Could not find volume named %s in members map", name)
+		}
+	}
+
+	// Try parsing as a direct single volume object
+	if _, hasID := rawResponse["id"]; hasID {
+		log.Trace("Detected single volume object response")
+		volume := &model.Volume{}
+		err = jsonutil.Decode(rawResponse, volume)
+		if err != nil {
+			return nil, fmt.Errorf("Error while decoding single volume response, err: %s", err.Error())
 		}
 		log.Tracef("Found volume: %s with ID: %s", volume.Name, volume.ID)
 		return volume, nil


### PR DESCRIPTION
JIRA Link :  https://jira.storage.hpecorp.net/browse/CON-4177

BUG Description : Static provisioning with Unified File is failing when attaching PVC to Pod

BUG Fix : 
This change updates the file volume handling logic in controller_server.go and node_server.go by replacing calls to GetVolumeByID with GetVolumeByName. the return handling for FileShare has been properly implemented to ensure the resolved file share details are correctly propagated through the workflow. After making these Changes the Pod are coming in running state.

`
root@rashiubuntu:~/CON-4177_yamls# k get pods -n hpe-storage
NAME                                              READY   STATUS    RESTARTS   AGE
alletrastoragemp-b10000-nfs-csp-c594795f8-sn66b   1/1     Running   0          25d
dep6-645c686669-mxrbd                             1/1     Running   0          32d
hpe-csi-controller-6686c4dd85-gkfqw               9/9     Running   0          8m1s
hpe-csi-node-2dkbs                                2/2     Running   0          7m34s
hpe-csi-node-ww8vl                                2/2     Running   0          8m
nimble-csp-67f7bbfff6-886t6                       1/1     Running   0          32d
primera3par-csp-748f8f6579-nrszh                  1/1     Running   0          32d
web-server-uf-857c575c78-lj7gz                    1/1     Running   0          19s
`
Attaching Logs on JIRA.