### PR TITLE
CON-4441-Inline ephemeral scrubber traversing entire filesystems

### DIFF
--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -747,6 +747,18 @@ func (driver *Driver) ScrubEphemeralPods(podsDirPath string) error {
 	log.Trace(">>>>> ScrubEphemeralPods")
 	defer log.Trace("<<<<< ScrubEphemeralPods")
 
+	const (
+		// Expected relative path shape under podsDirPath:
+		// <pod-uid>/volumes/kubernetes.io~csi/<pvc-id>/ephemeral_data.json
+		// This puts ephemeral_data.json at depth 5 from podsDirPath.
+		// Valid absolute example:
+		// /var/lib/kubelet/pods/109086aa-0d13-4d64-a5f9-72187f683b5d/volumes/kubernetes.io~csi/pvc-b53ab2fe-614c-4b45-bb24-4c7a629037b1/ephemeral_data.json
+		// Deeper mount-content example (intentionally ignored by depth pruning):
+		// /var/lib/kubelet/pods/109086aa-0d13-4d64-a5f9-72187f683b5d/volumes/kubernetes.io~csi/pvc-b53ab2fe-614c-4b45-bb24-4c7a629037b1/mount/000-scrubber-blocked
+		maxEphemeralDataFilePathDepth = 5
+		maxEphemeralDirPathDepth      = maxEphemeralDataFilePathDepth - 1
+	)
+
 	// Check if pods path exists
 	exists, isDir, err := util.FileExists(podsDirPath)
 	if err != nil {
@@ -760,20 +772,68 @@ func (driver *Driver) ScrubEphemeralPods(podsDirPath string) error {
 	//ephemeralPods := map[string][]*StagingDeviceEphemeralData{}
 	ephemeralPods := map[string][]*VolumeHandleTargetPath{}
 	err = filepath.Walk(podsDirPath, func(fileFullPath string, info os.FileInfo, walkErr error) error {
+		// Handle walk errors first — before any other work — to avoid unnecessary computation
 		if walkErr != nil {
 			log.Errorf("Error while processing the path [%s], %s", fileFullPath, walkErr.Error())
-			return walkErr
+			// Earlier behavior returned walkErr here, which aborted traversal and caused
+			// ScrubEphemeralPods to exit on the first inaccessible path.
+			// Current behavior is best-effort by design:
+			// - Directory error: return filepath.SkipDir to skip that subtree and continue.
+			// - File error: log the error and return nil, because there is no subtree to
+			//   descend into and returning walkErr would abort the whole scrubber run.
+			if info != nil && info.IsDir() {
+				// Skip processing current directory and continue processing other directories
+				return filepath.SkipDir
+			}
+			return nil
 		}
+
 		if info == nil {
+			// Skip processing current directory and continue processing other directories
 			log.Warnf("FileInfo is nil, Skipping directory path [%s]", fileFullPath)
-			return filepath.SkipDir /* Skip processing current directory and continue processing other directories */
+			return filepath.SkipDir
+		}
+
+		relPath, relErr := filepath.Rel(podsDirPath, fileFullPath)
+		if relErr != nil {
+			log.Errorf("Failed to evaluate relative path from pods path [%s] to [%s], %s", podsDirPath, fileFullPath, relErr.Error())
+			if info.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		pathDepth := 0
+		if relPath != "." {
+			pathDepth = len(strings.Split(relPath, string(os.PathSeparator)))
+		}
+		log.Tracef("Scrubber evaluating path [%s], relPath [%s], depth [%d]", fileFullPath, relPath, pathDepth)
+
+		if info.IsDir() {
+			// Depth check first: avoids opening/listing directories we will never use
+			if pathDepth > maxEphemeralDirPathDepth {
+				return filepath.SkipDir
+			}
+			log.Tracef("Scrubber processing directory [%s], relPath [%s], depth [%d]", fileFullPath, relPath, pathDepth)
+			// At depth 2 (example: <pod-uid>/volumes), only the "volumes" directory can lead
+			// to inline CSI metadata. Skip siblings like <pod-uid>/containers or <pod-uid>/plugins.
+			if pathDepth == 2 && info.Name() != "volumes" {
+				return filepath.SkipDir
+			}
+			// At depth 3 under volumes (example: <pod-uid>/volumes/kubernetes.io~csi), only the
+			// CSI plugin directory contains ephemeral_data.json. Skip other plugins (for example,
+			// <pod-uid>/volumes/kubernetes.io~secret).
+			if pathDepth == 3 && info.Name() != "kubernetes.io~csi" {
+				return filepath.SkipDir
+			}
+			return nil
 		}
 
 		// Process only 'ephemeral_data.json' files
-		if !info.IsDir() && info.Name() == ephemeralDataFileName {
+		if info.Name() == ephemeralDataFileName && pathDepth == maxEphemeralDataFilePathDepth {
 			log.Tracef("Found Ephemeral data file [%s]", fileFullPath)
 			targetDirPath := filepath.Dir(fileFullPath)
-			targetPath := fmt.Sprintf("%s/%s", targetDirPath, "mount")
+			targetPath := filepath.Join(targetDirPath, "mount")
 
 			// Load Ephemeral Data
 			ephemeralData, err := loadEphemeralData(targetDirPath, ephemeralDataFileName)

--- a/pkg/driver/scrubber_test.go
+++ b/pkg/driver/scrubber_test.go
@@ -1,0 +1,162 @@
+// Copyright 2019 Hewlett Packard Enterprise Development LP
+package driver
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/hpe-storage/csi-driver/pkg/flavor/vanilla"
+	"github.com/stretchr/testify/assert"
+)
+
+type scrubberTestFlavor struct {
+	*vanilla.Flavor
+	podUIDs   []string
+	podExists bool
+}
+
+func newScrubberTestFlavor(podExists bool) *scrubberTestFlavor {
+	return &scrubberTestFlavor{Flavor: &vanilla.Flavor{}, podExists: podExists}
+}
+
+func (flavor *scrubberTestFlavor) IsPodExists(uid string) (bool, error) {
+	flavor.podUIDs = append(flavor.podUIDs, uid)
+	return flavor.podExists, nil
+}
+
+func TestScrubEphemeralPodsSkipsDeepFilesystemPaths(t *testing.T) {
+	podsDirPath := t.TempDir()
+	podUID := "pod-deep"
+
+	ephemeralDataPath := filepath.Join(
+		podsDirPath,
+		podUID,
+		"volumes",
+		"kubernetes.io~csi",
+		"pvc-123",
+		"mount",
+		"nested",
+		ephemeralDataFileName,
+	)
+	writeTestEphemeralDataFile(t, ephemeralDataPath, podUID)
+
+	testFlavor := newScrubberTestFlavor(false)
+	driver := &Driver{flavor: testFlavor}
+
+	err := driver.ScrubEphemeralPods(podsDirPath)
+	assert.NoError(t, err)
+	assert.Empty(t, testFlavor.podUIDs)
+}
+
+func TestScrubEphemeralPodsSkipsNonCSIPluginPaths(t *testing.T) {
+	podsDirPath := t.TempDir()
+	podUID := "pod-noncsi"
+
+	ephemeralDataPath := filepath.Join(
+		podsDirPath,
+		podUID,
+		"volumes",
+		"kubernetes.io~foo",
+		"pvc-123",
+		ephemeralDataFileName,
+	)
+	writeTestEphemeralDataFile(t, ephemeralDataPath, podUID)
+
+	testFlavor := newScrubberTestFlavor(false)
+	driver := &Driver{flavor: testFlavor}
+
+	err := driver.ScrubEphemeralPods(podsDirPath)
+	assert.NoError(t, err)
+	assert.Empty(t, testFlavor.podUIDs)
+}
+
+func TestScrubEphemeralPodsProcessesValidCSIPath(t *testing.T) {
+	podsDirPath := t.TempDir()
+	podUID := "pod-valid"
+
+	ephemeralDataPath := filepath.Join(
+		podsDirPath,
+		podUID,
+		"volumes",
+		"kubernetes.io~csi",
+		"pvc-123",
+		ephemeralDataFileName,
+	)
+	writeTestEphemeralDataFile(t, ephemeralDataPath, podUID)
+
+	testFlavor := newScrubberTestFlavor(true)
+	driver := &Driver{flavor: testFlavor}
+
+	err := driver.ScrubEphemeralPods(podsDirPath)
+	assert.NoError(t, err)
+	assert.Equal(t, []string{podUID}, testFlavor.podUIDs)
+}
+
+// TestScrubEphemeralPodsHybridPruning validates the hybrid approach:
+// depth-based pruning + name-based pruning
+// This ensures robustness against:
+// 1. Deep filesystem walks into mounted content
+// 2. Non-CSI plugin paths
+// 3. Future Kubernetes path naming changes
+func TestScrubEphemeralPodsHybridPruning(t *testing.T) {
+	podsDirPath := t.TempDir()
+	podUID := "pod-hybrid"
+
+	// Valid path with correct structure
+	validPath := filepath.Join(
+		podsDirPath,
+		podUID,
+		"volumes",
+		"kubernetes.io~csi",
+		"pvc-xyz",
+		ephemeralDataFileName,
+	)
+	writeTestEphemeralDataFile(t, validPath, podUID)
+
+	// Create a deep path with ephemeral_data.json that should be skipped
+	deepPath := filepath.Join(
+		podsDirPath,
+		podUID,
+		"volumes",
+		"kubernetes.io~csi",
+		"pvc-xyz",
+		"mount",
+		"app-data",
+		ephemeralDataFileName,
+	)
+	writeTestEphemeralDataFile(t, deepPath, "deep-pod-id")
+
+	testFlavor := newScrubberTestFlavor(true)
+	driver := &Driver{flavor: testFlavor}
+
+	err := driver.ScrubEphemeralPods(podsDirPath)
+	assert.NoError(t, err)
+	// Should only find the valid pod, not the deep-nested one
+	assert.Equal(t, []string{podUID}, testFlavor.podUIDs)
+}
+
+func writeTestEphemeralDataFile(t *testing.T, filePath string, podUID string) {
+	t.Helper()
+
+	err := os.MkdirAll(filepath.Dir(filePath), 0o755)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	ephemeralData := &Ephemeral{
+		VolumeID:     "volume-id",
+		VolumeHandle: "volume-handle",
+		PodData: &POD{
+			UID: podUID,
+		},
+	}
+	payload, err := json.Marshal(ephemeralData)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	err = os.WriteFile(filePath, payload, 0o644)
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
Bug Link - https://jira.storage.hpecorp.net/browse/CON-4441

RCA - The scrubber performed an unbounded filesystem traversal under /var/lib/kubelet/pods, causing it to enter mounted volume data (mount/) and encounter permission-restricted directories. The fix constrains traversal depth and path structure to prevent entering mounted filesystems and handles per-path errors non-fatally.

Bug Fix Explanation - 
**Line 751** - This sets the expected depth of the metadata file relative to the pods root.
The intended path shape is:
pods / podUID / volumes / kubernetes.io~csi / pvc-id / ephemeral_data.json
That file sits at depth 5.
**Line 752** - This says the deepest directory we care about is the PVC directory at depth 4.
Anything deeper than that is not scrubber metadata territory and should be pruned.
**Line 768** -
This is one of the main fixes.
The code now checks walkErr before doing anything else.
This is the key change from the buggy version, which returned the raw error and aborted the entire walk.
**Line 782** - The scrubber computes the path relative to the pods root so it can reason about path depth instead of absolute strings.
**Line 798** - If a directory is deeper than the PVC directory level, the scrubber returns SkipDir immediately.
This is the core protection that stops traversal from entering mount content such as:
mount / qtrees / data / rdiff-backup-data
That is why the scrubber no longer walks entire NFS filesystems.
**Line 812** - This is another key fix.
The code only accepts ephemeral_data.json if it appears at exactly the expected depth.
So even if a file with that name exists deeper inside a mounted filesystem, it will be ignored.
**Line 815** - Builds the expected mount target path using filepath.Join.
This is cleaner and safer than string concatenation.

Bug Fix Results - 
Added some temporary logs to check traversal

`time="2026-03-23T12:00:31Z" level=info msg="GRPC response: {\"name\":\"csi.hpe.com\",\"vendor_version\":\"1.3\"}" file="utils.go:76"
time="2026-03-23T12:00:31Z" level=info msg="Scrubber processing directory [/var/lib/kubelet/pods/109086aa-0d13-4d64-a5f9-72187f683b5d/volumes/kubernetes.io~csi] at depth [3]" file="driver.go:801"
time="2026-03-23T12:00:31Z" level=info msg="Scrubber processing directory [/var/lib/kubelet/pods/109086aa-0d13-4d64-a5f9-72187f683b5d/volumes/kubernetes.io~csi/pvc-b53ab2fe-614c-4b45-bb24-4c7a629037b1] at depth [4]" file="driver.go:801"
time="2026-03-23T12:00:31Z" level=info msg="Scrubber processing directory [/var/lib/kubelet/pods/109086aa-0d13-4d64-a5f9-72187f683b5d/volumes/kubernetes.io~projected] at depth [3]" file="driver.go:801"
time="2026-03-23T12:00:31Z" level=info msg="Scrubber processing directory [/var/lib/kubelet/pods/1708d64d-7844-4fb6-be7b-c5f9eb96d7c4] at depth [1]" file="driver.go:801"
time="2026-03-23T12:00:31Z" level=info msg="Scrubber processing directory [/var/lib/kubelet/pods/1708d64d-7844-4fb6-be7b-c5f9eb96d7c4/containers] at depth [2]" file="driver.go:801"
time="2026-03-23T12:00:31Z" level=info msg="Scrubber processing directory [/var/lib/kubelet/pods/1708d64d-7844-4fb6-be7b-c5f9eb96d7c4/plugins] at depth [2]" file="driver.go:801"
time="2026-03-23T12:00:31Z" level=info msg="Scrubber processing directory [/var/lib/kubelet/pods/1708d64d-7844-4fb6-be7b-c5f9eb96d7c4/volumes] at depth [2]" file="driver.go:801"
time="2026-03-23T12:00:31Z" level=info msg="Scrubber processing directory [/var/lib/kubelet/pods/1708d64d-7844-4fb6-be7b-c5f9eb96d7c4/volumes/kubernetes.io~csi] at depth [3]" file="driver.go:801"
time="2026-03-23T12:00:31Z" level=info msg="Scrubber processing directory [/var/lib/kubelet/pods/1708d64d-7844-4fb6-be7b-c5f9eb96d7c4/volumes/kubernetes.io~csi/pvc-01f9cec0-28d1-45ab-9f2a-1440dbb146d8] at depth [4]" file="driver.go:801"`

What the logs prove
The scrubber is pruning non-target branches correctly.
It processes:
pod dir at depth 1
volumes at depth 2
kubernetes.io~csi at depth 3
pvc at depth 4

Added Unit Test File to cover scrubber code.