### PR TITLE
HF CSP integration with CSI

### DIFF
--- a/cmd/csi-driver/csi-driver_test.go
+++ b/cmd/csi-driver/csi-driver_test.go
@@ -1,0 +1,10 @@
+// Copyright 2026 Hewlett Packard Enterprise Development LP
+package main
+
+import "testing"
+
+func TestRootCmdIsInitialized(t *testing.T) {
+	if RootCmd == nil {
+		t.Fatalf("RootCmd must be initialized")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Scalingo/go-etcd-lock/v5 v5.0.8
 	github.com/container-storage-interface/spec v1.9.0
 	github.com/golang/protobuf v1.5.4
-	github.com/hpe-storage/common-host-libs v0.0.0-20260323052316-399e47ed2351
+	github.com/hpe-storage/common-host-libs v0.0.0-20260409061252-0c0b03231cb4
 	github.com/hpe-storage/k8s-custom-resources v0.0.0-20260119040638-398cb5cb0d42
 	github.com/kubernetes-csi/csi-lib-utils v0.11.0
 	github.com/kubernetes-csi/csi-test v2.2.0+incompatible

--- a/pkg/driver/constants.go
+++ b/pkg/driver/constants.go
@@ -4,11 +4,11 @@ package driver
 
 const (
 	// Protocol types
-	iscsi = "iscsi"
-	fc    = "fc"
-	nvmeotcp = "nvmeotcp"
+	iscsi           = "iscsi"
+	fc              = "fc"
+	nvmeotcp        = "nvmeotcp"
 	defaultNvmePort = "4420"
-	nvmetcp = "nvmetcp"
+	nvmetcp         = "nvmetcp"
 
 	// defaultFileSystem is the implemenation-specific default value
 	defaultFileSystem = "xfs"
@@ -127,5 +127,11 @@ const (
 
 	defaultCSITopologyKey = "csi.hpe.com/zone"
 	// FileSystem Corruption parameters
-	fsRepairKey          = "fsRepair"
+	fsRepairKey = "fsRepair"
+
+	// File volume constants
+	fileExportIPKey      = "exportIP"
+	mountPathKey         = "mountPath"
+	fileVolumeNameKey    = "csi.storage.k8s.io/pv/name"
+	accessControlListKey = "accessControlList"
 )

--- a/pkg/driver/controller_server.go
+++ b/pkg/driver/controller_server.go
@@ -440,6 +440,13 @@ func (driver *Driver) createVolume(
 		// Check if the existing volume's size matches with the requested size
 		// TODO: Nimble doesn't support capacity range, but other SP might.
 		// We may consider adding range support in the future???
+		// If CSP returns size 0 for an existing volume, treat it as the
+		// requested size and continue. This avoids creating duplicate
+		// volumes when the backend does not report the existing size.
+		if existingVolume.Size == 0 {
+			log.Warnf("Volume %s with ID %s has size 0 reported from CSP, treating it as size %d", existingVolume.Name, existingVolume.ID, size)
+			existingVolume.Size = size
+		}
 		if existingVolume.Size != size {
 			log.Errorf("Volume already exists with size %v but different size %v being requested.",
 				existingVolume.Size, size)
@@ -730,9 +737,8 @@ func (driver *Driver) deleteVolume(volumeID string, secrets map[string]string, f
 	// check if snapshots exist
 	if len(snapshots) > 0 {
 		log.Tracef("Found snapshots for volume %s: %+v", volumeID, snapshots)
-		return status.Errorf(codes.FailedPrecondition, "Volume %s with ID %s cannot be deleted as it has snapshots attached", existingVolume.Name, existingVolume.ID)
+		return status.Error(codes.FailedPrecondition, fmt.Sprintf("Volume %s with ID %s cannot be deleted as it has snapshots attached", existingVolume.Name, existingVolume.ID))
 	}
-
 	// Delete the volume from the array
 	log.Infof("About to delete volume %s with force=%v", volumeID, force)
 	if err := storageProvider.DeleteVolume(volumeID, force); err != nil {
@@ -740,7 +746,6 @@ func (driver *Driver) deleteVolume(volumeID string, secrets map[string]string, f
 		return status.Error(codes.Internal,
 			fmt.Sprintf("Error while deleting volume %s, err: %s", existingVolume.Name, err.Error()))
 	}
-
 	// Delete DB entry
 	if err := driver.RemoveFromDB(existingVolume.Name); err != nil {
 		return err
@@ -864,23 +869,32 @@ func (driver *Driver) controllerPublishVolume(
 	}
 
 	if driver.IsFileRequest(volumeContext) {
-		// Get storageProvider using secrets
+
+		publishOptions := &model.PublishFileOptions{
+			Name:              volumeContext[fileVolumeNameKey],
+			AccessProtocol:    volumeContext[accessProtocolKey],
+			AccessControlList: volumeContext[accessControlListKey],
+		}
+
 		storageProvider, err := driver.GetStorageProvider(secrets)
 		if err != nil {
 			log.Error("err: ", err.Error())
 			return nil, status.Error(codes.Unavailable,
 				fmt.Sprintf("Failed to get storage provider from secrets, err: %s", err.Error()))
 		}
-		_, err = storageProvider.PublishVolume(volumeID, nodeID, volumeContext[accessProtocolKey])
+
+		publishFileVol, err := storageProvider.PublishFileVolume(volumeID, publishOptions)
 		if err != nil {
 			log.Errorf("Failed to publish volume %s, err: %s", volumeID, err.Error())
 			return nil, status.Error(codes.Internal,
 				fmt.Sprintf("Failed to add file share settings access for volume %s for node %s via File CSP, err: %s", volumeID, nodeID, err.Error()))
 		}
+
 		log.Info("ControllerPublish requested with file resources, returning success")
 		return map[string]string{
-			readOnlyKey:        strconv.FormatBool(readOnlyAccessMode),
-			nfsMountOptionsKey: volumeContext[nfsMountOptionsKey],
+			readOnlyKey:     strconv.FormatBool(readOnlyAccessMode),
+			fileExportIPKey: publishFileVol.ExportIP,
+			mountPathKey:    publishFileVol.MountPath,
 		}, nil
 	}
 

--- a/pkg/driver/node_server.go
+++ b/pkg/driver/node_server.go
@@ -41,7 +41,6 @@ var (
 )
 
 const (
-	fileHostIPKey = "hostIP"
 	targetPortKey = "targetPort"
 )
 
@@ -895,31 +894,12 @@ func (driver *Driver) NodePublishVolume(ctx context.Context, request *csi.NodePu
 	// Check if volume is requested with File resources and intercept here
 	if driver.IsFileRequest(request.VolumeContext) {
 		log.Infof("NodePublish requested with file resources for %s", request.VolumeId)
-		existingVolume, err := driver.GetVolumeByID(request.VolumeId, request.Secrets)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get volume %s, err: %s", request.VolumeId, err.Error())
+		if request.PublishContext == nil {
+			return nil, status.Error(codes.InvalidArgument,
+				fmt.Sprintf("publish context is nil for file volume %s", request.VolumeId))
 		}
-		if existingVolume.Config != nil {
-			hostIPVal, ok := existingVolume.Config[fileHostIPKey]
-			if ok && hostIPVal != nil {
-				hostIP, ok := hostIPVal.(string)
-				if ok && hostIP != "" && isValidIP(hostIP) {
-					log.Infof("Adding hostIP %s to volume context for volume %s", hostIP, request.VolumeId)
-					request.VolumeContext[fileHostIPKey] = hostIP
-				} else {
-					log.Errorf("failed to get hostIP for volume %s", request.VolumeId)
-					return nil, fmt.Errorf("failed to get hostIP for volume %s", request.VolumeId)
-				}
-			} else {
-				log.Errorf("hostIP key not found or value is nil in config for volume %s", request.VolumeId)
-				return nil, fmt.Errorf("hostIP key not found or value is nil in config for volume %s", request.VolumeId)
-			}
-		} else {
-			log.Errorf("config is nil for volume %s", request.VolumeId)
-			return nil, fmt.Errorf("config is nil for volume %s", request.VolumeId)
-		}
-
-		return driver.flavor.HandleFileNodePublish(request)
+		mountOptions := getMountOptionsFromVolCap(request.VolumeCapability)
+		return driver.flavor.HandleFileNodePublish(request, mountOptions)
 	}
 	// If ephemeral volume request, then create new volume, add ACL and NodeStage/NodePublish
 	if ephemeral {

--- a/pkg/flavor/kubernetes/file.go
+++ b/pkg/flavor/kubernetes/file.go
@@ -14,8 +14,9 @@ import (
 const (
 	NFS              = "nfs"
 	shareNfsVersion  = "shareNfsVersion"
-	fileHostIPKey    = "hostIP"
+	fileExportIPKey  = "exportIP"
 	fileMountPathKey = "mountPath"
+	mountOptionsKey  = "mountOptions"
 )
 
 // HandleFileNodePublish handles the NodePublishVolume request for file-based volumes in a Kubernetes environment.
@@ -36,35 +37,21 @@ const (
 // - A NodePublishVolumeResponse on successful mount.
 // - An error if any step in the process fails.
 
-func (flavor *Flavor) HandleFileNodePublish(req *csi.NodePublishVolumeRequest) (*csi.NodePublishVolumeResponse, error) {
+func (flavor *Flavor) HandleFileNodePublish(req *csi.NodePublishVolumeRequest, mountOptions []string) (*csi.NodePublishVolumeResponse, error) {
 	log.Tracef(">>>>> HandleFileNodePublish with volume %s target path %s", req.VolumeId, req.TargetPath)
 	defer log.Tracef("<<<<< HandleFileNodePublish")
-	var mountOptions []string
-	var clusterIP, exportPath string
-	var existHostIP, existExportPath bool
-	clusterIP, existHostIP = req.VolumeContext[fileHostIPKey]
-	exportPath, existExportPath = req.VolumeContext[fileMountPathKey]
-	if !existHostIP || !existExportPath {
-		errStr := fmt.Sprintf("failed to create file provisioned volume with hostip: %s, and mount path: %s, host ip or mount path should not be empty ", clusterIP, exportPath)
+	var exportIP, exportPath string
+	var exportIPExists, exportPathExists bool
+	exportIP, exportIPExists = req.PublishContext[fileExportIPKey]
+	exportPath, exportPathExists = req.PublishContext[fileMountPathKey]
+	if !exportIPExists || !exportPathExists || exportIP == "" || exportPath == "" {
+		errStr := fmt.Sprintf("failed to create file provisioned volume with exportIP: %s, and mount path: %s, exportIP or mount path should not be empty ", exportIP, exportPath)
 		log.Errorln(errStr)
 		return nil, status.Error(codes.Internal, errStr)
 	}
-	source := fmt.Sprintf("%s:%s", clusterIP, exportPath)
+	source := fmt.Sprintf("%s:%s", exportIP, exportPath)
 	target := req.GetTargetPath()
-	mountOptions = getNFSMountOptions(req.VolumeContext)
-	defaultShareNfsVersion := req.VolumeContext[shareNfsVersion]
-	if defaultShareNfsVersion == "" {
-		defaultShareNfsVersion = "4"
-	}
-	nfsComandArgs := fmt.Sprintf("%s%s", NFS, defaultShareNfsVersion)
-	if len(mountOptions) == 0 {
-		// use default mount options, i.e (rw,relatime,vers=4.0,rsize=1048576,wsize=1048576,namlen=255,hard,proto=tcp,timeo=600,retrans=2,sec=sys,local_lock=none)
-		mountOptions = []string{
-			"nolock",
-			"vers=4",
-		}
-	}
-	mountOptions = append(mountOptions, fmt.Sprintf("addr=%s", clusterIP))
+	mountOptions = append(mountOptions, fmt.Sprintf("addr=%s", exportIP))
 	if req.GetReadonly() {
 		mountOptions = append(mountOptions, "ro")
 	}
@@ -72,7 +59,7 @@ func (flavor *Flavor) HandleFileNodePublish(req *csi.NodePublishVolumeRequest) (
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
-	if err := flavor.chapiDriver.MountNFSVolume(source, target, mountOptions, nfsComandArgs); err != nil {
+	if err := flavor.chapiDriver.MountNFSVolume(source, target, mountOptions, ""); err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 	return &csi.NodePublishVolumeResponse{}, nil

--- a/pkg/flavor/types.go
+++ b/pkg/flavor/types.go
@@ -45,5 +45,5 @@ type Flavor interface {
 	ListVolumeAttachments() (*storage_v1.VolumeAttachmentList, error)
 	GetChapCredentials(volumeContext map[string]string) (*model.ChapInfo, error)
 	CheckConnection() bool
-	HandleFileNodePublish(request *csi.NodePublishVolumeRequest) (*csi.NodePublishVolumeResponse, error)
+	HandleFileNodePublish(request *csi.NodePublishVolumeRequest, mountOptions []string) (*csi.NodePublishVolumeResponse, error)
 }

--- a/pkg/flavor/vanilla/flavor.go
+++ b/pkg/flavor/vanilla/flavor.go
@@ -155,6 +155,6 @@ func (flavor *Flavor) CheckConnection() bool {
 }
 
 //nolint:revive
-func (flavor *Flavor) HandleFileNodePublish(request *csi.NodePublishVolumeRequest) (*csi.NodePublishVolumeResponse, error) {
+func (flavor *Flavor) HandleFileNodePublish(request *csi.NodePublishVolumeRequest, mountOptions []string) (*csi.NodePublishVolumeResponse, error) {
 	return nil, status.Error(codes.Internal, "File provisioned volume is not supported for non-k8s environments")
 }

--- a/pkg/flavor/vanilla/flavor_test.go
+++ b/pkg/flavor/vanilla/flavor_test.go
@@ -1,0 +1,11 @@
+// Copyright 2026 Hewlett Packard Enterprise Development LP
+package vanilla
+
+import "testing"
+
+func TestFlavorCanBeCreated(t *testing.T) {
+	flavor := &Flavor{}
+	if flavor == nil {
+		t.Fatalf("Flavor must be created")
+	}
+}

--- a/pkg/nodeinit/nodeinit_test.go
+++ b/pkg/nodeinit/nodeinit_test.go
@@ -1,0 +1,11 @@
+// Copyright 2026 Hewlett Packard Enterprise Development LP
+package nodeinit
+
+import "testing"
+
+func TestNewNodeInitContainerReturnsInstance(t *testing.T) {
+	nic := NewNodeInitContainer("vanilla")
+	if nic == nil {
+		t.Fatalf("expected non-nil NodeInitContainer")
+	}
+}

--- a/vendor/github.com/hpe-storage/common-host-libs/model/types.go
+++ b/vendor/github.com/hpe-storage/common-host-libs/model/types.go
@@ -496,16 +496,19 @@ type ProcMount struct {
 
 // PublishOptions are the options needed to publish a file volume
 type PublishFileOptions struct {
-	Name           string `json:"name,omitempty"`
-	HostUUID       string `json:"host_uuid,omitempty"`
-	AccessProtocol string `json:"access_protocol,omitempty"`
-	VolumeID       string `json:"volume_id,omitempty"`
-	AccessIP       string `json:"access_ip,omitempty"`
+	Name              string `json:"name,omitempty"`
+	AccessProtocol    string `json:"access_protocol,omitempty"`
+	AccessControlList string `json:"access_control_list,omitempty"`
 }
 
 // PublishFileInfo is the node side data required to access a volume
 type PublishFileInfo struct {
-	HostIP    string `json:"host_ip,omitempty"`
+	ExportIP  string `json:"export_ip,omitempty"`
 	MountPath string `json:"mount_path,omitempty"`
-	//TODO can contain more info if needed
+}
+
+// UnPublishFileOptions are the options needed to unpublish a file volume
+type UnPublishFileOptions struct {
+	Name              string `json:"name,omitempty"`
+	AccessControlList string `json:"access_control_list,omitempty"`
 }

--- a/vendor/github.com/hpe-storage/common-host-libs/storageprovider/csp/container_storage_provider.go
+++ b/vendor/github.com/hpe-storage/common-host-libs/storageprovider/csp/container_storage_provider.go
@@ -529,15 +529,15 @@ func (provider *ContainerStorageProvider) PublishVolume(id, hostUUID, accessProt
 	return response, err
 }
 
-// PublishFileVolume will make a volume visible (add an ACL) to the given host
-func (provider *ContainerStorageProvider) PublishFileVolume(publishFileOptions *model.PublishFileOptions) (*model.PublishFileInfo, error) {
+// PublishFileVolume will make a file volume visible (add an ACL) to the given host
+func (provider *ContainerStorageProvider) PublishFileVolume(id string, publishFileOptions *model.PublishFileOptions) (*model.PublishFileInfo, error) {
 	response := &model.PublishFileInfo{}
 	var errorResponse *ErrorsPayload
 
 	status, err := provider.invoke(
 		&connectivity.Request{
 			Action:        "PUT",
-			Path:          fmt.Sprintf("/containers/v1/volumes/%s/actions/publish", publishFileOptions.VolumeID),
+			Path:          fmt.Sprintf("/containers/v1/volumes/%s/actions/publish", id),
 			Payload:       publishFileOptions,
 			Response:      &response,
 			ResponseError: &errorResponse,
@@ -568,6 +568,27 @@ func (provider *ContainerStorageProvider) UnpublishVolume(id, hostUUID string) e
 	}
 
 	return err
+}
+
+// UnPublishFileVolume will remove the access_control_list from the file export
+func (provider *ContainerStorageProvider) UnPublishFileVolume(id string, unPublishFileOptions *model.UnPublishFileOptions) (*model.PublishFileInfo, error) {
+	response := &model.PublishFileInfo{}
+	var errorResponse *ErrorsPayload
+
+	status, err := provider.invoke(
+		&connectivity.Request{
+			Action:        "PUT",
+			Path:          fmt.Sprintf("/containers/v1/volumes/%s/actions/unpublish", id),
+			Payload:       unPublishFileOptions,
+			Response:      &response,
+			ResponseError: &errorResponse,
+		},
+	)
+	if errorResponse != nil {
+		return nil, handleError(status, errorResponse)
+	}
+
+	return response, err
 }
 
 // ExpandVolume will expand the volume to reqeusted size

--- a/vendor/github.com/hpe-storage/common-host-libs/storageprovider/fake/fake_storage_provider.go
+++ b/vendor/github.com/hpe-storage/common-host-libs/storageprovider/fake/fake_storage_provider.go
@@ -288,8 +288,18 @@ func (provider *StorageProvider) EditVolume(id string, parameters map[string]int
 	return &fakeVolume, nil
 }
 
-func (provider *StorageProvider) PublishFileVolume(publishOptions *model.PublishFileOptions) (*model.PublishFileInfo, error) {
+// PublishFileVolume will return fake publish data for a file volume
+func (provider *StorageProvider) PublishFileVolume(id string, publishOptions *model.PublishFileOptions) (*model.PublishFileInfo, error) {
 	return &model.PublishFileInfo{
-		HostIP: "eui.fake",
+		ExportIP:  "eui.fake",
+		MountPath: "eui.fake",
+	}, nil
+}
+
+// UnPublishFileVolume will make a file volume invisible (remove an ACL) from the given host
+func (provider *StorageProvider) UnPublishFileVolume(id string, unPublishFileOptions *model.UnPublishFileOptions) (*model.PublishFileInfo, error) {
+	return &model.PublishFileInfo{
+		ExportIP:  "eui.fake",
+		MountPath: "eui.fake",
 	}, nil
 }

--- a/vendor/github.com/hpe-storage/common-host-libs/storageprovider/storage_provider.go
+++ b/vendor/github.com/hpe-storage/common-host-libs/storageprovider/storage_provider.go
@@ -36,8 +36,9 @@ type StorageProvider interface {
 	CloneVolume(name, description, sourceID, snapshotID string, size int64, opts map[string]interface{}) (*model.Volume, error)
 	DeleteVolume(id string, force bool) error
 	PublishVolume(id, hostUUID, accessProtocol string) (*model.PublishInfo, error) // Idempotent
-	PublishFileVolume(publishOptions *model.PublishFileOptions) (*model.PublishFileInfo, error)
+	PublishFileVolume(id string, publishOptions *model.PublishFileOptions) (*model.PublishFileInfo, error)
 	UnpublishVolume(id, hostUUID string) error // Idempotent
+	UnPublishFileVolume(id string, unPublishFileOptions *model.UnPublishFileOptions) (*model.PublishFileInfo, error)
 	ExpandVolume(id string, requestBytes int64) (*model.Volume, error)
 	GetSnapshot(id string) (*model.Snapshot, error)
 	GetSnapshotByName(name string, sourceVolID string) (*model.Snapshot, error)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -101,7 +101,7 @@ github.com/gorilla/mux
 # github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.3
 ## explicit; go 1.23.0
 github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2/options
-# github.com/hpe-storage/common-host-libs v0.0.0-20260323052316-399e47ed2351
+# github.com/hpe-storage/common-host-libs v0.0.0-20260409061252-0c0b03231cb4
 ## explicit; go 1.24.0
 github.com/hpe-storage/common-host-libs/chapi
 github.com/hpe-storage/common-host-libs/concurrent


### PR DESCRIPTION
Updated the go.mod file to bring in latest common-host-libs

change constant value for svc name unified file csp



add support for delete and unpublish (#13)



if indirect network add all ips of the node (#14)



store hostIP to annotation (#15)



clone hf (#16)



design change for hf csi


hf csi integration