### PR TITLE
CON-4646 Added pre-check to filter invalid values for the nfsResources parameter with appropriate error message

### DIFF
--- a/pkg/driver/controller_server.go
+++ b/pkg/driver/controller_server.go
@@ -304,6 +304,10 @@ func (driver *Driver) createVolume(
 			filesystem = defaultFileSystem
 			log.Trace("Using default filesystem type: ", filesystem)
 		}
+		// Validate nfsResources value if present - provide a clear error for invalid values
+		if nfsResourcesVal, ok := createParameters[nfsResourcesKey]; ok && !strings.EqualFold(nfsResourcesVal, trueKey) {
+			return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("invalid value '%s' for StorageClass parameter %s, the only valid value is '%s'", nfsResourcesVal, nfsResourcesKey, trueKey))
+		}
 		if driver.IsSupportedMultiNodeAccessMode(volumeCapabilities) && !(driver.IsNFSResourceRequest(createParameters) || driver.IsFileRequest(createParameters)) {
 			return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("StorageClass parameter %s=%s is missing for creation of volumes with multi-node access for NFS or  StorageClass parameter %s=%s is missing for creation of volumes with multi-node access File", nfsResourcesKey, trueKey, accessProtocolKey, nfsFileSystem))
 		}


### PR DESCRIPTION
CON-4646 Added pre-check to filter invalid values for the nfsResources parameter with appropriate error message

Error Message: "failed to provision volume with StorageClass "hpe-sync-replication-app-sc-nfs2": rpc error: code = InvalidArgument desc = invalid value 'enable' for StorageClass parameter nfsResources, the only valid value is 'true'"