### PR TITLE
Remove OwnerReference from NFS PVCs

### DIFF
--- a/pkg/flavor/kubernetes/nfs.go
+++ b/pkg/flavor/kubernetes/nfs.go
@@ -801,6 +801,11 @@ func (flavor *Flavor) createNFSPVC(claim *core_v1.PersistentVolumeClaim, nfsName
 	log.Tracef(">>>>> createNFSPVC with claim %s", claim.ObjectMeta.Name)
 	defer log.Tracef("<<<<< createNFSPVC")
 
+	// remove ownerReferences as they're managed elsewhere
+	if claim.ObjectMeta.OwnerReferences != nil {
+		claim.ObjectMeta.OwnerReferences = []meta_v1.OwnerReference{}
+	}
+
 	// create new underlying nfs claim
 	newClaim, err := flavor.kubeClient.CoreV1().PersistentVolumeClaims(nfsNamespace).Create(context.Background(), claim, meta_v1.CreateOptions{})
 	if err != nil {


### PR DESCRIPTION
This PR stops propagation of OwnerReferences to NFS Server Provisioner PVCs.
- Closes #295, #488 and internal ref CON-2574

Passes e2e with ephemeral volumes enabled on OpenShift 4.22:
```
Ran 47 of 7673 Specs in 2333.486 seconds
SUCCESS! -- 47 Passed | 0 Failed | 0 Pending | 7626 Skipped
PASS
```