### PR TITLE
Increase the recommended number of PV to more than 500 by CSI Driver

### DIFF
--- a/pkg/driver/node_server.go
+++ b/pkg/driver/node_server.go
@@ -971,12 +971,6 @@ func (driver *Driver) nodePublishVolume(
 		volumeID, stagingTargetPath, targetPath)
 	defer log.Trace("<<<<< nodePublishVolume")
 
-	// Get Volume
-	if _, err := driver.GetVolumeByID(volumeID, secrets); err != nil {
-		log.Error("Failed to get volume ", volumeID)
-		return status.Error(codes.NotFound, err.Error())
-	}
-
 	// Read device info from the staging area
 	stagingDev, err := readStagedDeviceInfo(stagingTargetPath)
 	if err != nil {


### PR DESCRIPTION
…end number of PV to more than 500 by CSI Driver , The NodePublish operation has a dependency on the array to

check if the volume is present. However, if we have reached this state, it means the volume should already be present. At scale, removing this check significantly reduces pressure on the CSP.We also observed that at scale, even if the volume was created on the array, the CRD creation sometimes failed silently. In these cases, the PVC becomes Bound, but NodePublish fails because GetVolumeByID depends on the CRD.The CSP CRD issue is being resolved in a separate PR.