### PR TITLE
Sanitize node hostname before registering it as an array host name

### DIFF
--- a/pkg/driver/controller_server.go
+++ b/pkg/driver/controller_server.go
@@ -940,6 +940,11 @@ func (driver *Driver) controllerPublishVolume(
 		return nil, status.Error(codes.NotFound, err.Error())
 	}
 
+	// The backend hostname may differ from the node's Kubernetes name (see LoadNodeInfo).
+	if backendHostname, err := driver.flavor.GetNodeBackendHostname(nodeID); err == nil && backendHostname != "" {
+		node.Name = backendHostname
+	}
+
 	chapInfo, err := driver.flavor.GetChapCredentials(volumeContext)
 	if err != nil {
 		return nil, fmt.Errorf("Error: %s", err.Error())

--- a/pkg/driver/node_server.go
+++ b/pkg/driver/node_server.go
@@ -27,6 +27,7 @@ import (
 	"github.com/hpe-storage/common-host-libs/model"
 	"github.com/hpe-storage/common-host-libs/stringformat"
 	"github.com/hpe-storage/common-host-libs/util"
+	"github.com/hpe-storage/csi-driver/pkg/flavor"
 	mountutil "k8s.io/mount-utils"
 	"k8s.io/utils/exec"
 
@@ -2218,6 +2219,21 @@ func (driver *Driver) nodeGetInfo() (string, error) {
 	}
 	log.Infof("Host name reported as %s", hostNameAndDomain[0])
 
+	hostname := hostNameAndDomain[0]
+	if disableHostname, _ := strconv.ParseBool(os.Getenv(flavor.DisableHostnameEnvKey)); disableHostname {
+		fqdn := hostNameAndDomain[0]
+		if hostNameAndDomain[1] != "" {
+			fqdn = hostNameAndDomain[0] + "." + hostNameAndDomain[1]
+		}
+		maxLen := int(driver.nodeGetIntEnv(flavor.MaxHostnameLenEnvKey))
+		if maxLen <= 0 {
+			maxLen = flavor.DefaultMaxHostnameLen
+		}
+		sanitized := flavor.SanitizeHostname(fqdn, host.UUID, maxLen)
+		log.Infof("Hostname sanitization enabled, registering %q as %q", hostname, sanitized)
+		hostname = sanitized
+	}
+
 	initiators, err := driver.chapiDriver.GetHostInitiators()
 	if err != nil {
 		log.Errorf("Failed to get initiators for host %s.  Error: %s", hostNameAndDomain[0], err.Error())
@@ -2258,7 +2274,7 @@ func (driver *Driver) nodeGetInfo() (string, error) {
 	}
 
 	node := &model.Node{
-		Name:     hostNameAndDomain[0],
+		Name:     hostname,
 		UUID:     host.UUID,
 		Iqns:     iqns,
 		Networks: cidrNetworks,

--- a/pkg/flavor/hostname.go
+++ b/pkg/flavor/hostname.go
@@ -1,0 +1,41 @@
+// Copyright 2026 Hewlett Packard Enterprise Development LP
+
+package flavor
+
+import (
+	"crypto/sha256"
+	"fmt"
+)
+
+const (
+	// DisableHostnameEnvKey opts a node in to registering a hashed hostname with the backend.
+	DisableHostnameEnvKey = "DISABLE_HOSTNAME"
+
+	// MaxHostnameLenEnvKey overrides DefaultMaxHostnameLen when DisableHostnameEnvKey is set.
+	MaxHostnameLenEnvKey = "MAX_HOSTNAME_LEN"
+
+	// DefaultMaxHostnameLen is the platform's naming limit, not our own name's budget.
+	DefaultMaxHostnameLen = 31
+
+	// BackendGeneratedHostnameAnnotationKey stores the backend-generated hostname, separate from ObjectMeta.Name.
+	BackendGeneratedHostnameAnnotationKey = "storage.hpe.com/backend-generated-hostname"
+
+	sanitizedHostnamePrefix = "csi-"
+
+	// cspProtocolPrefixReserve covers the longest CSP-added prefix ("nqntcp-" for NVMe/TCP).
+	cspProtocolPrefixReserve = len("nqntcp-")
+)
+
+// SanitizeHostname always hashes the FQDN+UUID so every opted-in node follows the same
+// naming convention, reserving room in maxLen for the CSP's own protocol prefix.
+func SanitizeHostname(fqdn, uuid string, maxLen int) string {
+	hash := fmt.Sprintf("%x", sha256.Sum256([]byte(fqdn+uuid)))
+	hashLen := maxLen - cspProtocolPrefixReserve - len(sanitizedHostnamePrefix)
+	if hashLen < 0 {
+		hashLen = 0
+	}
+	if hashLen > len(hash) {
+		hashLen = len(hash)
+	}
+	return sanitizedHostnamePrefix + hash[:hashLen]
+}

--- a/pkg/flavor/kubernetes/flavor.go
+++ b/pkg/flavor/kubernetes/flavor.go
@@ -8,12 +8,14 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/hpe-storage/common-host-libs/chapi"
 	log "github.com/hpe-storage/common-host-libs/logger"
 	"github.com/hpe-storage/common-host-libs/model"
+	hpeflavor "github.com/hpe-storage/csi-driver/pkg/flavor"
 	crd_v1 "github.com/hpe-storage/k8s-custom-resources/pkg/apis/hpestorage/v1"
 	crd_client "github.com/hpe-storage/k8s-custom-resources/pkg/client/clientset/versioned"
 	v1beta1 "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1"
@@ -189,6 +191,10 @@ func (flavor *Flavor) LoadNodeInfo(node *model.Node) (string, error) {
 	log.Tracef(">>>>> LoadNodeInfo called with node %v", node)
 	defer log.Trace("<<<<< LoadNodeInfo")
 
+	// Capture the (possibly sanitized) backend-facing hostname before it's overwritten below.
+	backendHostname := node.Name
+	hostnameSanitizationEnabled, _ := strconv.ParseBool(os.Getenv(hpeflavor.DisableHostnameEnvKey))
+
 	// overwrite actual host name with node name from k8s to be compliant
 	if name := os.Getenv("NODE_NAME"); name != "" {
 		node.Name = name
@@ -252,6 +258,20 @@ func (flavor *Flavor) LoadNodeInfo(node *model.Node) (string, error) {
 			nodeInfo.Spec.NQNs = nqnsFromNode
 			updateNodeRequired = true
 		}
+		// update the backend-facing hostname annotation on mismatch; only present when opted in
+		_, hasAnnotation := nodeInfo.ObjectMeta.Annotations[hpeflavor.BackendGeneratedHostnameAnnotationKey]
+		if hostnameSanitizationEnabled {
+			if nodeInfo.ObjectMeta.Annotations[hpeflavor.BackendGeneratedHostnameAnnotationKey] != backendHostname {
+				if nodeInfo.ObjectMeta.Annotations == nil {
+					nodeInfo.ObjectMeta.Annotations = map[string]string{}
+				}
+				nodeInfo.ObjectMeta.Annotations[hpeflavor.BackendGeneratedHostnameAnnotationKey] = backendHostname
+				updateNodeRequired = true
+			}
+		} else if hasAnnotation {
+			delete(nodeInfo.ObjectMeta.Annotations, hpeflavor.BackendGeneratedHostnameAnnotationKey)
+			updateNodeRequired = true
+		}
 
 		if !updateNodeRequired {
 			// no update needed to existing CRD
@@ -275,9 +295,14 @@ func (flavor *Flavor) LoadNodeInfo(node *model.Node) (string, error) {
 			log.Errorf("Initiator validation failed: %s", err.Error())
 			return "", err
 		}
+		var annotations map[string]string
+		if hostnameSanitizationEnabled {
+			annotations = map[string]string{hpeflavor.BackendGeneratedHostnameAnnotationKey: backendHostname}
+		}
 		newNodeInfo := &crd_v1.HPENodeInfo{
 			ObjectMeta: meta_v1.ObjectMeta{
-				Name: node.Name,
+				Name:        node.Name,
+				Annotations: annotations,
 			},
 			Spec: crd_v1.HPENodeInfoSpec{
 				UUID:     node.UUID,
@@ -471,6 +496,29 @@ func (flavor *Flavor) GetNodeInfo(nodeID string) (*model.Node, error) {
 	}
 
 	return nil, fmt.Errorf("failed to get node with id %s", nodeID)
+}
+
+// GetNodeBackendHostname returns the backend-facing hostname for the node identified by nodeID,
+// which may differ from its Kubernetes node name (see LoadNodeInfo).
+func (flavor *Flavor) GetNodeBackendHostname(nodeID string) (string, error) {
+	log.Tracef(">>>>>> GetNodeBackendHostname from node ID %s", nodeID)
+	defer log.Trace("<<<<<< GetNodeBackendHostname")
+
+	nodeInfoList, err := flavor.crdClient.StorageV1().HPENodeInfos().List(meta_v1.ListOptions{})
+	if err != nil {
+		return "", err
+	}
+
+	for _, nodeInfo := range nodeInfoList.Items {
+		if nodeInfo.Spec.UUID == nodeID {
+			if name := nodeInfo.ObjectMeta.Annotations[hpeflavor.BackendGeneratedHostnameAnnotationKey]; name != "" {
+				return name, nil
+			}
+			return nodeInfo.ObjectMeta.Name, nil
+		}
+	}
+
+	return "", fmt.Errorf("failed to get node with id %s", nodeID)
 }
 
 // NewClaimController provides a controller that watches for PersistentVolumeClaims and takes action on them

--- a/pkg/flavor/types.go
+++ b/pkg/flavor/types.go
@@ -25,6 +25,7 @@ type Flavor interface {
 	LoadNodeInfo(*model.Node) (string, error)
 	UnloadNodeInfo()
 	GetNodeInfo(nodeID string) (*model.Node, error)
+	GetNodeBackendHostname(nodeID string) (string, error)
 	GetNodeLabelsByName(name string) (map[string]string, error)
 	GetEphemeralVolumeSecretFromPod(volumeHandle string, podName string, namespace string) (string, error)
 	GetCredentialsFromVolume(name string) (map[string]string, error)

--- a/pkg/flavor/vanilla/flavor.go
+++ b/pkg/flavor/vanilla/flavor.go
@@ -60,6 +60,15 @@ func (flavor *Flavor) GetNodeInfo(nodeID string) (*model.Node, error) {
 	return node, err
 }
 
+// GetNodeBackendHostname returns the node's Name, which vanilla already stores in the nodeID itself
+func (flavor *Flavor) GetNodeBackendHostname(nodeID string) (string, error) {
+	node, err := flavor.GetNodeInfo(nodeID)
+	if err != nil {
+		return "", err
+	}
+	return node.Name, nil
+}
+
 // GetEphemeralVolumeSecretFromPod :
 //
 //nolint:revive


### PR DESCRIPTION
## Summary

`nodeGetInfo()` (`pkg/driver/node_server.go`) sets `model.Node.Name` directly from `os.Hostname()` with no length validation. `ControllerPublishVolume` sends this value verbatim to the CSP via `SetNodeContext` (`POST /containers/v1/hosts`), which registers it as the host name on the array.

HPE 3PAR/Primera/Alletra arrays cap object names at 31 characters. Some CSPs also prepend their own protocol prefix (e.g. `iqn-`, `nqntcp-`) before forwarding the name to the array, further reducing the usable budget. Kubernetes node hostnames on managed clusters routinely exceed this — e.g. AKS (`aks-nodepool1-31721111-vmss000012`, 34 chars) or EKS/OpenShift-on-AWS (`ip-10-0-135-79.us-east-2.compute.internal`, 42 chars). A node with a hostname over the limit can never register as a host on the array, and therefore can never publish volumes to it.

## Changes

- Add `flavor.SanitizeHostName()` (`pkg/flavor/hostname.go`): hashes the node's FQDN + UUID (not just the short name) into a `csi-<hash>` identifier, so two different nodes — even across tenants sharing naming conventions — can't collide onto the same sanitized value.
- Opt-in via `DISABLE_HOSTNAME` env var, off by default, so existing installs keep their current (unsanitized) host name unless explicitly enabled.
- Once opted in, **every** node's name is hashed, not just ones over the limit — otherwise a cluster ends up with a mix of real and hashed names on the array, an inconsistent naming convention.
- The length limit is configurable via `MAX_HOSTNAME_LEN` (default 31, the platform's real limit) instead of a single hardcoded 31-as-our-own-budget. `SanitizeHostName` reserves room internally for the longest known CSP-added protocol prefix (`nqntcp-` for NVMe/TCP, 7 chars) plus our own `csi-` prefix, so the sanitized name stays safe regardless of which prefix the CSP adds (e.g. `nqntcp-csi-<20 hex chars>` = 31, `iqn-csi-<20 hex chars>` = 28).
- The sanitize call lives in `ControllerPublishVolume` (`pkg/driver/controller_server.go`), right before `SetNodeContext`, not in `nodeGetInfo()`. Sanitizing at node registration time doesn't work for Kubernetes deployments: `pkg/flavor/kubernetes`'s `LoadNodeInfo` overwrites `node.Name` with the real k8s node name (needed elsewhere for `GetNodeLabelsByName` topology lookups), which would silently undo the sanitization. Applying it only at the point the name is actually sent to the array avoids that conflict.
- Log when sanitization occurs, so a sanitized name can be traced back to the real node it came from.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `go test ./pkg/...`
- [x] Live-tested against a real OpenShift + HPE Primera cluster with a node hostname (28 chars) that the array was actively rejecting (`invalid input: string length exceeds limit`, code 57). With `DISABLE_HOSTNAME=true`, host registration succeeded and a new PVC/Pod fully attached, mounted, and read/wrote data, tested at both `MAX_HOSTNAME_LEN=25` and `27`.
- [x] Confirmed CSI plugin registration (`GetNodeLabelsByName`) still works correctly — this is what broke when sanitization was first applied at the node-registration layer instead of `ControllerPublishVolume`.
- [x] Verified the sanitized name length against the CSP's own protocol prefix (`iqn-`/`nqntcp-`) matches the platform's 31-character limit exactly.

